### PR TITLE
Ignore gh-pages branch in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+branches:
+  except:
+    - gh-pages
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Not sure how to test this but any documentation changes will make the travis build fail. One other
way is to add a `Gemfile` to the `gh-pages` branch but I didn't opt for that since that will run the build.
