### PR TITLE
Expand directory path when reading an .ini file

### DIFF
--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -84,7 +84,7 @@ module Invoker
         OpenStruct.new(
           port: port,
           label: section["label"] || section.key,
-          dir: section["directory"],
+          dir: expand_directory(section["directory"]),
           cmd: replace_port_in_command(section["command"], port)
         )
       end
@@ -92,7 +92,7 @@ module Invoker
       def make_option(section)
         OpenStruct.new(
           label: section["label"] || section.key,
-          dir: section["directory"],
+          dir: expand_directory(section["directory"]),
           cmd: section["command"]
         )
       end
@@ -102,9 +102,13 @@ module Invoker
       end
 
       def check_directory(app_dir)
-        if app_dir && !app_dir.empty? && !File.directory?(app_dir)
+        if app_dir && !app_dir.empty? && !File.directory?(expand_directory(app_dir))
           raise Invoker::Errors::InvalidConfig.new("Invalid directory #{app_dir}")
         end
+      end
+
+      def expand_directory(app_dir)
+        File.expand_path(app_dir) if app_dir
       end
 
       def replace_port_in_command(command, port)

--- a/spec/invoker/config_spec.rb
+++ b/spec/invoker/config_spec.rb
@@ -24,6 +24,37 @@ command = ruby try_sleep.rb
     end
   end
 
+  describe "with relative directory path" do
+    it "should expand path in commands" do
+      begin
+        file = Tempfile.new(["config", ".ini"])
+
+        config_data =<<-EOD
+[pwd_home]
+directory = ~
+command = pwd
+
+[pwd_parent]
+directory = ../
+command = pwd
+      EOD
+        file.write(config_data)
+        file.close
+
+        config = Invoker::Parsers::Config.new(file.path, 9000)
+        command1 = config.processes.first
+
+        expect(command1.dir).to match(File.expand_path('~'))
+
+        command2 = config.processes[1]
+
+        expect(command2.dir).to match(File.expand_path('..'))
+      ensure
+        file.unlink()
+      end
+    end
+  end
+
   describe "for ports" do
     it "should replace port in commands" do
       begin


### PR DESCRIPTION
In our team we all keep the code under `~/Code` but using the `~` in the invoker _ini_ file is impossible.

Since invoker uses `File.directory?` to check if the `directory` configuration is a valid configuration the path is not expanded and it will result in an `Invoker::Errors::InvalidConfig` exception.

This pull requests adds the path expansion that lets the file specify `~` prepended paths. If needed it should be easy to add the ability to use environment variables too. I intentionally left out that part since it requires a little more work (and I don't think it would be that useful).
