### PR TITLE
Lock RubyDNS to 0.8.x versions

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency("formatador", "~> 0.2")
   s.add_dependency("eventmachine", "~> 1.0")
   s.add_dependency("em-proxy", "~> 0.1")
-  s.add_dependency("rubydns", "~> 0.7")
+  s.add_dependency("rubydns", "~> 0.8.5")
   s.add_dependency("uuid", "~> 2.3")
   s.add_dependency("facter", "~> 2.2")
   s.add_dependency("http-parser-lite", "~> 0.6")


### PR DESCRIPTION
Invoker currently does not start on a new install because it will use RubyDNS 0.9.0 which was released on 10/23/14. This took an exceptionally long time to troubleshoot because of celluloid, but I finally tracked it down! Invoker's gemspec locks RubyDNS to `~> 0.7`, however [the author states](https://github.com/ioquatix/rubydns/issues/28) that `0.x` releases are incompatible, but minor versions should be compatible. Here is the [offending change](https://github.com/ioquatix/rubydns/compare/v0.8.5...v0.9.0#diff-d86035f01d9c6b072797c19b43eb736aL116) in 0.9.0.
For the time being you can add the following to your own `Gemfile`:

`gem 'rubydns', '~> 0.8.5'`

Here is a trace of what happens when you run with RubyDNS 0.9.0:

```
→ invoker start Procfile 
D, [2014-10-26T09:45:30.515304 #59891] DEBUG -- : Terminating 1 actor...
vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/calls.rb:39:in `check': wrong number of arguments (1 for 0) (ArgumentError)
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/calls.rb:24:in `dispatch'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/calls.rb:63:in `dispatch'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/cell.rb:60:in `block in invoke'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/cell.rb:71:in `block in task'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/actor.rb:357:in `block in task'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/tasks.rb:57:in `block in initialize'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/tasks/task_fiber.rb:15:in `block in create'
    from (celluloid):0:in `remote procedure call'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/calls.rb:92:in `value'
    from vendor/bundle/gems/celluloid-0.16.0/lib/celluloid/proxies/sync_proxy.rb:33:in `method_missing'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/power/powerup.rb:17:in `block in run'
    from vendor/bundle/bundler/gems/eventmachine-4d53154a9ea4/lib/eventmachine.rb:187:in `call'
    from vendor/bundle/bundler/gems/eventmachine-4d53154a9ea4/lib/eventmachine.rb:187:in `run_machine'
    from vendor/bundle/bundler/gems/eventmachine-4d53154a9ea4/lib/eventmachine.rb:187:in `run'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/power/powerup.rb:13:in `run'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/power/powerup.rb:7:in `block in fork_and_start'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/power/powerup.rb:7:in `fork'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/power/powerup.rb:7:in `fork_and_start'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/process_manager.rb:72:in `run_power_server'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/commander.rb:39:in `start_manager'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/cli.rb:46:in `start'
    from vendor/bundle/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from vendor/bundle/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from vendor/bundle/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from vendor/bundle/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from vendor/bundle/gems/invoker-1.3.0/lib/invoker/cli.rb:12:in `start'
    from vendor/bundle/gems/invoker-1.3.0/bin/invoker:7:in `<top (required)>'
    from ./bin/invoker:16:in `load'
    from ./bin/invoker:16:in `<main>'
```
