### PR TITLE
Update to dotenv ~> 1.0.2

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency("uuid", "~> 2.3")
   s.add_dependency("facter", "~> 2.2")
   s.add_dependency("http-parser-lite", "~> 0.6")
-  s.add_dependency("dotenv", "~> 0.9")
+  s.add_dependency("dotenv", "~> 1.0.2")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")
   s.add_development_dependency("rake")


### PR DESCRIPTION
[dotenv 1.0.2](https://github.com/bkeepers/dotenv/blob/master/Changelog.md#102---oct-14-2014) is out. all specs still pass.
