### PR TITLE
Support for processes that are inactive by default

### DIFF
--- a/lib/invoker/commander.rb
+++ b/lib/invoker/commander.rb
@@ -37,7 +37,7 @@ module Invoker
       unix_server_thread = Thread.new { Invoker::IPC::Server.new }
       @thread_group.add(unix_server_thread)
       process_manager.run_power_server
-      Invoker.config.autostartable_processes.each { |process_info| process_manager.start_process(process_info) }
+      Invoker.config.autorunnable_processes.each { |process_info| process_manager.start_process(process_info) }
       at_exit { process_manager.kill_workers }
       start_event_loop
     end

--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -27,8 +27,8 @@ module Invoker
         power_config && power_config.https_port
       end
 
-      def autostartable_processes
-        processes.reject { |pconfig| pconfig.autostart == false }
+      def autorunnable_processes
+        processes.reject(&:disable_autorun)
       end
 
       def process(label)
@@ -91,11 +91,10 @@ module Invoker
         pconfig = {
           label: section["label"] || section.key,
           dir: expand_directory(section["directory"]),
-          cmd: section["command"],
-          autostart: section['autostart'].nil? ? true : section['autostart']
+          cmd: section["command"]
         }
         pconfig['port'] = section['port'] if section['port']
-        pconfig['autostart'] = section['autostart'] if section['autostart'] == false
+        pconfig['disable_autorun'] = section['disable_autorun'] if section['disable_autorun']
 
         OpenStruct.new(pconfig)
       end

--- a/spec/invoker/commander_spec.rb
+++ b/spec/invoker/commander_spec.rb
@@ -20,7 +20,7 @@ describe "Invoker::Commander" do
       before do
         processes = [OpenStruct.new(:label => "foobar", :cmd => "foobar_command", :dir => ENV['HOME'])]
         invoker_config.stubs(:processes).returns(processes)
-        invoker_config.stubs(:autostartable_processes).returns(processes)
+        invoker_config.stubs(:autorunnable_processes).returns(processes)
         @commander = Invoker::Commander.new
         Invoker.commander = @commander
       end
@@ -53,7 +53,7 @@ describe "Invoker::Commander" do
       before do
         processes = [OpenStruct.new(:label => "foobar", :cmd => "foobar_command", :dir => ENV['HOME'])]
         invoker_config.stubs(:processes).returns(processes)
-        invoker_config.stubs(:autostartable_processes).returns(processes)
+        invoker_config.stubs(:autorunnable_processes).returns(processes)
         @commander = Invoker::Commander.new
         Invoker.commander = @commander
         Invoker.daemonize = true
@@ -87,21 +87,20 @@ describe "Invoker::Commander" do
     end
   end
 
-  describe 'autostart' do
-    context "a process can't be autostarted" do
+  describe 'disable_autorun option' do
+    context 'autorun is disabled for a process' do
       before do
         @processes = [
           OpenStruct.new(:label => "foobar", :cmd => "foobar_command", :dir => ENV['HOME']),
-          OpenStruct.new(:label => "panda", :cmd => "panda_command", :dir => ENV['HOME'], :autostart => false)
+          OpenStruct.new(:label => "panda", :cmd => "panda_command", :dir => ENV['HOME'], :disable_autorun => true)
         ]
         invoker_config.stubs(:processes).returns(@processes)
-        autostartable_processes = [OpenStruct.new(:label => "foobar", :cmd => "foobar_command", :dir => ENV['HOME'])]
-        invoker_config.stubs(:autostartable_processes).returns(autostartable_processes)
+        invoker_config.stubs(:autorunnable_processes).returns([@processes.first])
 
         @commander = Invoker::Commander.new
       end
 
-      it "doesn't start process" do
+      it "doesn't run process" do
         @commander.expects(:install_interrupt_handler)
         @commander.process_manager.expects(:run_power_server)
         @commander.expects(:at_exit)

--- a/spec/invoker/config_spec.rb
+++ b/spec/invoker/config_spec.rb
@@ -190,8 +190,8 @@ web: bundle exec rails s -p $PORT
     end
   end
 
-  describe "#autostartable_processes" do
-    it "returns a list of processes that can be autostarted" do
+  describe "#autorunnable_processes" do
+    it "returns a list of processes that can be autorun" do
       begin
         file = Tempfile.new(["config", ".ini"])
         config_data =<<-EOD
@@ -200,15 +200,15 @@ command = postgres -D /usr/local/var/postgres
 
 [redis]
 command = redis-server /usr/local/etc/redis.conf
-autostart = false
+disable_autorun = true
 
 [memcached]
 command = /usr/local/opt/memcached/bin/memcached
-autostart = true
+disable_autorun = false
 
 [panda-api]
 command = bundle exec rails s
-autostart = false
+disable_autorun = true
 
 [panda-auth]
 command = bundle exec rails s -p $PORT
@@ -217,7 +217,7 @@ command = bundle exec rails s -p $PORT
         file.close
 
         config = Invoker::Parsers::Config.new(file.path, 9000)
-        expect(config.autostartable_processes.map { |process_info| process_info.label }).to eq(['postgres', 'memcached', 'panda-auth'])
+        expect(config.autorunnable_processes.map(&:label)).to eq(['postgres', 'memcached', 'panda-auth'])
       ensure
         file.unlink()
       end


### PR DESCRIPTION
Ability to list a process in invoker.ini, but not have it autostarted by default

```
[postgres]
command = postgres -D /usr/local/var/postgres

[redis]
command = redis-server /usr/local/etc/redis.conf

[elasticsearch]
command = elasticsearch -f
autostart = false
```

`add` command can be used to start inactive processes later

```
invoker add elasticsearch
```
