### PR TITLE
Allow dots in application name

### DIFF
--- a/lib/invoker/power/balancer.rb
+++ b/lib/invoker/power/balancer.rb
@@ -22,7 +22,7 @@ module Invoker
 
     class Balancer
       attr_accessor :connection, :http_parser, :session, :protocol
-      DEV_MATCH_REGEX = /([\w-]+)\.dev(\:\d+)?$/
+      DEV_MATCH_REGEX = /([\w\.-]+)\.dev(\:\d+)?$/
       XIP_IO_MATCH_REGEX = /([\w-]+)\.\d+\.\d+\.\d+\.\d+\.xip\.io(\:\d+)?$/
 
       def self.run(options = {})

--- a/spec/invoker/power/balancer_spec.rb
+++ b/spec/invoker/power/balancer_spec.rb
@@ -27,7 +27,7 @@ describe Invoker::Power::Balancer do
       expect(match).to_not be_nil
 
       matching_string = match[1]
-      expect(matching_string).to eq("bar")
+      expect(matching_string).to eq("emacs.bar")
     end
 
     it "should match hello-world.dev" do


### PR DESCRIPTION
A possible solution to #116.

Allows defining `x.domain`, so that `x.domain.dev` can be used, but breaks accessing `x.domain.dev` if only `domain` is configured.

Would that be something that people are relying upon?