### PR TITLE
Load configuration scripts from a central location

### DIFF
--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -38,6 +38,10 @@ module Invoker
       private
 
       def load_config
+        if is_global?
+          @filename = to_global_file
+        end
+
         if is_ini?
           process_ini
         elsif is_procfile?
@@ -127,6 +131,14 @@ module Invoker
 
       def is_procfile?
         @filename =~ /Procfile/
+      end
+
+      def to_global_file
+        File.join(Invoker::Power::Config.config_dir, "#{@filename}.ini")
+      end
+
+      def is_global?
+        @filename =~ /^\w+$/ && File.exists?(to_global_file)
       end
     end
   end


### PR DESCRIPTION
This is a concept to load configuration scripts from a central location.

In particular, here, I'm loading them from ~/.invoker/[file].ini

So if you call `invoker start myapp` it'll search `~/.invoker/myapp.ini`