### PR TITLE
When Host is missing Invoker should return 400 Bad request response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ invoker_profile/
 .ruby-version
 Gemfile.lock
 .overcommit.yml
+Procfile

--- a/lib/invoker/power/balancer.rb
+++ b/lib/invoker/power/balancer.rb
@@ -64,6 +64,11 @@ module Invoker
           return
         end
         @session = UUID.generate()
+        if !headers['Host'] || headers['Host'].empty?
+          return_error_page(400)
+          return
+        end
+
         dns_check_response = UrlRewriter.new.select_backend_config(headers['Host'])
         if dns_check_response && dns_check_response.port
           connection.server(session, host: '0.0.0.0', port: dns_check_response.port)

--- a/lib/invoker/power/templates/400.html
+++ b/lib/invoker/power/templates/400.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Invoker</title>
+    <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background: #fff;
+      line-height: 18px;
+    }
+    div.page {
+      padding: 36px 90px;
+    }
+    h1, h2, p, li {
+      font-family: Helvetica, sans-serif;
+      font-size: 13px;
+    }
+    h1 {
+      line-height: 45px;
+      font-size: 36px;
+      margin: 0;
+    }
+    h2 {
+      line-height: 27px;
+      font-size: 18px;
+      font-weight: normal;
+      margin: 0;
+    }
+    </style>
+  </head>
+  <body class="">
+    <div class="page">
+      <h1>Bad request</h1>
+      <hr>
+      <h2>Invoker couldn't understand the request</h2>
+    </div>
+  </body>
+</html>

--- a/spec/invoker/power/balancer_spec.rb
+++ b/spec/invoker/power/balancer_spec.rb
@@ -1,5 +1,22 @@
 require 'spec_helper'
 
 describe Invoker::Power::Balancer do
+  before do
+    @http_connection = mock("connection")
+    @balancer = Invoker::Power::Balancer.new(@http_connection, "http")
+  end
 
+  context "when Host field is missing in the request" do
+    it "should return 400 as response when Host is missing" do
+      headers = {}
+      @http_connection.expects(:send_data).with() { |value| value =~ /400 Bad Request/i }
+      @balancer.headers_received(headers)
+    end
+
+    it "should return 400 as response when Host is empty" do
+      headers = { 'Host' => '' }
+      @http_connection.expects(:send_data).with() { |value| value =~ /400 Bad Request/i }
+      @balancer.headers_received(headers)
+    end
+  end
 end


### PR DESCRIPTION
Invoker can't function when header field `Host` is missing from
requests and hence we must return 400 bad request for such requests.