### PR TITLE
Support for groups

### DIFF
--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -67,7 +67,7 @@ module Invoker
       banner: "Signal to send for killing the process, default is SIGINT",
       aliases: [:s]
     def reload(name)
-      signal = options[:signal] || 'INT'
+      signal = options[:signal]
       unix_socket.send_command('reload', process_name: name, signal: signal)
     end
 
@@ -83,7 +83,7 @@ module Invoker
       banner: "Signal to send for killing the process, default is SIGINT",
       aliases: [:s]
     def remove(name)
-      signal = options[:signal] || 'INT'
+      signal = options[:signal]
       unix_socket.send_command('remove', process_name: name, signal: signal)
     end
 

--- a/lib/invoker/commander.rb
+++ b/lib/invoker/commander.rb
@@ -10,7 +10,7 @@ module Invoker
     attr_accessor :event_manager, :runnables, :thread_group
     extend Forwardable
 
-    def_delegators :@process_manager, :start_process_by_name, :start_process_or_group_by_name, :stop_process
+    def_delegators :@process_manager, :start_process_by_name, :start_process_or_group_by_name, :stop_process, :stop_process_or_group_by_name, :restart_process_or_group_by_name
     def_delegators :@process_manager, :restart_process, :get_worker_from_fd, :process_list
 
     def_delegators :@event_manager, :schedule_event, :trigger

--- a/lib/invoker/commander.rb
+++ b/lib/invoker/commander.rb
@@ -10,7 +10,7 @@ module Invoker
     attr_accessor :event_manager, :runnables, :thread_group
     extend Forwardable
 
-    def_delegators :@process_manager, :start_process_by_name, :stop_process
+    def_delegators :@process_manager, :start_process_by_name, :start_process_or_group_by_name, :stop_process
     def_delegators :@process_manager, :restart_process, :get_worker_from_fd, :process_list
 
     def_delegators :@event_manager, :schedule_event, :trigger

--- a/lib/invoker/commander.rb
+++ b/lib/invoker/commander.rb
@@ -10,7 +10,7 @@ module Invoker
     attr_accessor :event_manager, :runnables, :thread_group
     extend Forwardable
 
-    def_delegators :@process_manager, :start_process_by_name, :start_process_or_group_by_name, :stop_process, :stop_process_or_group_by_name, :restart_process_or_group_by_name
+    def_delegators :@process_manager, :start_process_by_name, :stop_process
     def_delegators :@process_manager, :restart_process, :get_worker_from_fd, :process_list
 
     def_delegators :@event_manager, :schedule_event, :trigger

--- a/lib/invoker/ipc/add_command.rb
+++ b/lib/invoker/ipc/add_command.rb
@@ -4,16 +4,16 @@ module Invoker
       def run_command(add_message)
         process_or_group_name = add_message.process_name
         processes = Invoker.config.processes_by_group_or_name(process_or_group_name)
-        
+
         unless processes.size == 1
           processes.each do |process_info|
             unix_socket = Invoker::IPC::UnixClient.new
             unix_socket.send_command('add', process_name: process_info.label)
           end
-        
+
           return true
         end
-        
+
         Invoker.commander.on_next_tick(add_message) do |add_message|
           start_process_by_name(add_message.process_name)
         end

--- a/lib/invoker/ipc/add_command.rb
+++ b/lib/invoker/ipc/add_command.rb
@@ -2,8 +2,20 @@ module Invoker
   module IPC
     class AddCommand < BaseCommand
       def run_command(add_message)
-        Invoker.commander.on_next_tick(add_message.process_name) do |process_or_group_name|
-          start_process_or_group_by_name(process_or_group_name)
+        process_or_group_name = add_message.process_name
+        processes = Invoker.config.processes_by_group_or_name(process_or_group_name)
+        
+        unless processes.size == 1
+          processes.each do |process_info|
+            unix_socket = Invoker::IPC::UnixClient.new
+            unix_socket.send_command('add', process_name: process_info.label)
+          end
+        
+          return true
+        end
+        
+        Invoker.commander.on_next_tick(add_message) do |add_message|
+          start_process_by_name(add_message.process_name)
         end
 
         true

--- a/lib/invoker/ipc/add_command.rb
+++ b/lib/invoker/ipc/add_command.rb
@@ -1,8 +1,8 @@
 module Invoker
   module IPC
     class AddCommand < BaseCommand
-      def run_command(message_object)
-        Invoker.commander.on_next_tick(message_object.process_name) do |process_or_group_name|
+      def run_command(add_message)
+        Invoker.commander.on_next_tick(add_message.process_name) do |process_or_group_name|
           start_process_or_group_by_name(process_or_group_name)
         end
 

--- a/lib/invoker/ipc/add_command.rb
+++ b/lib/invoker/ipc/add_command.rb
@@ -2,9 +2,10 @@ module Invoker
   module IPC
     class AddCommand < BaseCommand
       def run_command(message_object)
-        Invoker.commander.on_next_tick(message_object.process_name) do |process_name|
-          start_process_by_name(process_name)
+        Invoker.commander.on_next_tick(message_object.process_name) do |process_or_group_name|
+          start_process_or_group_by_name(process_or_group_name)
         end
+
         true
       end
     end

--- a/lib/invoker/ipc/reload_command.rb
+++ b/lib/invoker/ipc/reload_command.rb
@@ -1,10 +1,12 @@
 module Invoker
   module IPC
     class ReloadCommand < BaseCommand
-      def run_command(message_object)
-        Invoker.commander.on_next_tick(message_object) do |reload_message|
-          restart_process(reload_message)
+      def run_command(reload_message)
+        Invoker.commander.on_next_tick(reload_message) do |reload_message|
+          process_or_group_name = reload_message.process_name
+          restart_process_or_group_by_name(process_or_group_name, stop_signal: reload_message.signal)
         end
+
         true
       end
     end

--- a/lib/invoker/ipc/reload_command.rb
+++ b/lib/invoker/ipc/reload_command.rb
@@ -2,9 +2,20 @@ module Invoker
   module IPC
     class ReloadCommand < BaseCommand
       def run_command(reload_message)
+        process_or_group_name = reload_message.process_name
+        processes = Invoker.config.processes_by_group_or_name(process_or_group_name)
+
+        unless processes.size == 1
+          processes.each do |process_info|
+            unix_socket = Invoker::IPC::UnixClient.new
+            unix_socket.send_command('reload', process_name: process_info.label, signal: reload_message.signal)
+          end
+
+          return true
+        end
+
         Invoker.commander.on_next_tick(reload_message) do |reload_message|
-          process_or_group_name = reload_message.process_name
-          restart_process_or_group_by_name(process_or_group_name, stop_signal: reload_message.signal)
+          restart_process(reload_message.process_name, stop_signal: reload_message.signal)
         end
 
         true

--- a/lib/invoker/ipc/remove_command.rb
+++ b/lib/invoker/ipc/remove_command.rb
@@ -1,10 +1,12 @@
 module Invoker
   module IPC
     class RemoveCommand < BaseCommand
-      def run_command(message_object)
-        Invoker.commander.on_next_tick(message_object) do |remove_message|
-          stop_process(remove_message)
+      def run_command(remove_message)
+        Invoker.commander.on_next_tick(remove_message) do |remove_message|
+          process_or_group_name = remove_message.process_name
+          stop_process_or_group_by_name(process_or_group_name, stop_signal: remove_message.signal)
         end
+
         true
       end
     end

--- a/lib/invoker/ipc/remove_command.rb
+++ b/lib/invoker/ipc/remove_command.rb
@@ -2,9 +2,20 @@ module Invoker
   module IPC
     class RemoveCommand < BaseCommand
       def run_command(remove_message)
+        process_or_group_name = remove_message.process_name
+        processes = Invoker.config.processes_by_group_or_name(process_or_group_name)
+
+        unless processes.size == 1
+          processes.each do |process_info|
+            unix_socket = Invoker::IPC::UnixClient.new
+            unix_socket.send_command('remove', process_name: process_info.label, signal: remove_message.signal)
+          end
+
+          return true
+        end
+
         Invoker.commander.on_next_tick(remove_message) do |remove_message|
-          process_or_group_name = remove_message.process_name
-          stop_process_or_group_by_name(process_or_group_name, stop_signal: remove_message.signal)
+          stop_process(remove_message.process_name, stop_signal: remove_message.signal)
         end
 
         true

--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -46,6 +46,10 @@ module Invoker
         processes.detect { |pconfig| pconfig.label == label }
       end
 
+      def processes_by_group_or_name(process_or_group_name)
+        processes.select { |pconfig| pconfig.group == process_or_group_name || pconfig.label == process_or_group_name }
+      end
+
       private
 
       def autodetect_config_file
@@ -116,7 +120,8 @@ module Invoker
         pconfig = {
           label: section["label"] || section.key,
           dir: expand_directory(section["directory"]),
-          cmd: section["command"]
+          cmd: section["command"],
+          group: section["group"]
         }
         pconfig['port'] = section['port'] if section['port']
         pconfig['disable_autorun'] = section['disable_autorun'] if section['disable_autorun']

--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -121,7 +121,8 @@ module Invoker
           label: section["label"] || section.key,
           dir: expand_directory(section["directory"]),
           cmd: section["command"],
-          group: section["group"]
+          group: section["group"],
+          stop_signal: section['stop_signal']
         }
         pconfig['port'] = section['port'] if section['port']
         pconfig['disable_autorun'] = section['disable_autorun'] if section['disable_autorun']

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -26,11 +26,6 @@ module Invoker
       wait_on_pid(process_info.label, pid)
     end
 
-    def start_process_or_group_by_name(process_or_group_name)
-      processes_to_start = Invoker.config.processes_by_group_or_name(process_or_group_name)
-      processes_to_start.each { |process_info| start_process_by_name(process_info.label) }
-    end
-
     # Start a process given their name
     # @param process_name [String] Command label of process specified in config file.
     def start_process_by_name(process_name)
@@ -41,11 +36,6 @@ module Invoker
 
       process_info = Invoker.config.process(process_name)
       start_process(process_info) if process_info
-    end
-
-    def stop_process_or_group_by_name(process_or_group_name, options)
-      processes_to_stop = Invoker.config.processes_by_group_or_name(process_or_group_name)
-      processes_to_stop.each { |process_info| stop_process(process_info.label, options) }
     end
 
     # Remove a process from list of processes managed by invoker supervisor.It also
@@ -63,11 +53,6 @@ module Invoker
 
       Invoker::Logger.puts("Removing #{process_name} with signal #{signal_to_use}".color(:red))
       kill_or_remove_process(worker.pid, signal_to_use, process_name)
-    end
-
-    def restart_process_or_group_by_name(process_or_group_name, options)
-      processes_to_restart = Invoker.config.processes_by_group_or_name(process_or_group_name)
-      processes_to_restart.each { |process_info| restart_process(process_info.label, options) }
     end
 
     # Receive a message from user to restart a Process

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -56,7 +56,10 @@ module Invoker
     def stop_process(process_name, options = {})
       worker = workers[process_name]
       return false unless worker
-      signal_to_use = options[:stop_signal] || 'INT'
+
+      signal_to_use = options[:stop_signal]
+      signal_to_use ||= Invoker.config.process(process_name).stop_signal
+      signal_to_use ||= 'INT'
 
       Invoker::Logger.puts("Removing #{process_name} with signal #{signal_to_use}".color(:red))
       kill_or_remove_process(worker.pid, signal_to_use, process_name)

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -43,31 +43,39 @@ module Invoker
       start_process(process_info) if process_info
     end
 
+    def stop_process_or_group_by_name(process_or_group_name, options)
+      processes_to_stop = Invoker.config.processes_by_group_or_name(process_or_group_name)
+      processes_to_stop.each { |process_info| stop_process(process_info.label, options) }
+    end
+
     # Remove a process from list of processes managed by invoker supervisor.It also
     # kills the process before removing it from the list.
     #
-    # @param remove_message [Invoker::IPC::Message::Remove]
+    # @param process_name [String] Command label of process specified in config file.
     # @return [Boolean] if process existed and was removed else false
-    def stop_process(remove_message)
-      worker = workers[remove_message.process_name]
-      command_label = remove_message.process_name
+    def stop_process(process_name, options = {})
+      worker = workers[process_name]
       return false unless worker
-      signal_to_use = remove_message.signal || 'INT'
+      signal_to_use = options[:stop_signal] || 'INT'
 
-      Invoker::Logger.puts("Removing #{command_label} with signal #{signal_to_use}".color(:red))
-      kill_or_remove_process(worker.pid, signal_to_use, command_label)
+      Invoker::Logger.puts("Removing #{process_name} with signal #{signal_to_use}".color(:red))
+      kill_or_remove_process(worker.pid, signal_to_use, process_name)
+    end
+
+    def restart_process_or_group_by_name(process_or_group_name, options)
+      processes_to_restart = Invoker.config.processes_by_group_or_name(process_or_group_name)
+      processes_to_restart.each { |process_info| restart_process(process_info.label, options) }
     end
 
     # Receive a message from user to restart a Process
-    # @param [Invoker::IPC::Message::Reload]
-    def restart_process(reload_message)
-      command_label = reload_message.process_name
-      if stop_process(reload_message.remove_message)
-        Invoker.commander.schedule_event(command_label, :worker_removed) do
-          start_process_by_name(command_label)
+    # @param process_name [String] Command label of process specified in config file.
+    def restart_process(process_name, options)
+      if stop_process(process_name, options)
+        Invoker.commander.schedule_event(process_name, :worker_removed) do
+          start_process_by_name(process_name)
         end
       else
-        start_process_by_name(command_label)
+        start_process_by_name(process_name)
       end
     end
 

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -26,6 +26,11 @@ module Invoker
       wait_on_pid(process_info.label, pid)
     end
 
+    def start_process_or_group_by_name(process_or_group_name)
+      processes_to_start = Invoker.config.processes_by_group_or_name(process_or_group_name)
+      processes_to_start.each { |process_info| start_process_by_name(process_info.label) }
+    end
+
     # Start a process given their name
     # @param process_name [String] Command label of process specified in config file.
     def start_process_by_name(process_name)

--- a/spec/invoker/config_spec.rb
+++ b/spec/invoker/config_spec.rb
@@ -190,6 +190,29 @@ web: bundle exec rails s -p $PORT
     end
   end
 
+  describe 'stop signal option' do
+    it 'allows specifying a custom stop signal for each process' do
+      begin
+        file = Tempfile.new(["config", ".ini"])
+        config_data =<<-EOD
+[postgres]
+command = postgres -D /usr/local/var/postgres
+stop_signal = TERM
+
+[redis]
+command = redis-server /usr/local/etc/redis.conf
+EOD
+        file.write(config_data)
+        file.close
+
+        config = Invoker::Parsers::Config.new(file.path, 9000)
+        config.process('postgres').stop_signal.should == 'TERM'
+      ensure
+        file.unlink()
+      end
+    end
+  end
+
   describe "#autorunnable_processes" do
     it "returns a list of processes that can be autorun" do
       begin

--- a/spec/invoker/ipc/client_handler_spec.rb
+++ b/spec/invoker/ipc/client_handler_spec.rb
@@ -5,30 +5,69 @@ describe Invoker::IPC::ClientHandler do
   let(:client) { Invoker::IPC::ClientHandler.new(client_socket) }
 
   describe "add command" do
-    let(:message_object) { MM::Add.new(process_name: 'foo') }
     it "should run if read from socket" do
-      invoker_commander.expects(:on_next_tick).with("foo")
-      client_socket.string = message_object.encoded_message
+      begin
+        file = File.open("invoker.ini", "w")
+        config_data =<<-EOD
+[foo]
+command = bar
+        EOD
+        file.write(config_data)
+        file.close
+        Invoker.load_invoker_config(file, 3000)
 
-      client.read_and_execute
+        message_object = MM::Add.new(process_name: 'foo')
+        invoker_commander.expects(:on_next_tick).with { |message_object| message_object.process_name == 'foo' }
+        client_socket.string = message_object.encoded_message
+
+        client.read_and_execute
+      ensure
+        File.delete(file)
+      end
     end
   end
 
   describe "remove command" do
     it "with specific signal" do
-      message_object = MM::Remove.new(process_name: 'foo', signal: 'INT')
-      invoker_commander.expects(:on_next_tick)
-      client_socket.string = message_object.encoded_message
+      begin
+        file = File.open("invoker.ini", "w")
+        config_data =<<-EOD
+[foo]
+command = bar
+        EOD
+        file.write(config_data)
+        file.close
+        Invoker.load_invoker_config(file, 3000)
 
-      client.read_and_execute
+        message_object = MM::Remove.new(process_name: 'foo', signal: 'INT')
+        invoker_commander.expects(:on_next_tick)
+        client_socket.string = message_object.encoded_message
+
+        client.read_and_execute
+      ensure
+        File.delete(file)
+      end
     end
 
     it "with default signal" do
-      message_object = MM::Remove.new(process_name: 'foo')
-      invoker_commander.expects(:on_next_tick)
-      client_socket.string = message_object.encoded_message
+      begin
+        file = File.open("invoker.ini", "w")
+        config_data =<<-EOD
+[foo]
+command = bar
+        EOD
+        file.write(config_data)
+        file.close
+        Invoker.load_invoker_config(file, 3000)
 
-      client.read_and_execute
+        message_object = MM::Remove.new(process_name: 'foo')
+        invoker_commander.expects(:on_next_tick)
+        client_socket.string = message_object.encoded_message
+
+        client.read_and_execute
+      ensure
+        File.delete(file)
+      end
     end
   end
 

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -2,6 +2,20 @@ require "spec_helper"
 
 describe Invoker::ProcessManager do
   let(:process_manager) { Invoker::ProcessManager.new }
+
+  describe '#start_process_or_group_by_name' do
+    it 'finds processes by group or process name and starts them' do
+      processes_to_start = [
+        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
+        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
+      ]
+      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_start)
+      process_manager.expects(:start_process_by_name).with('postgres')
+      process_manager.expects(:start_process_by_name).with('redis')
+      process_manager.start_process_or_group_by_name('db')
+    end
+  end
+
   describe "#start_process_by_name" do
     it "should find command by label and start it, if found" do
       invoker_config.stubs(:processes).returns([OpenStruct.new(:label => "resque", :cmd => "foo", :dir => "bar")])

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -4,11 +4,12 @@ describe Invoker::ProcessManager do
   let(:process_manager) { Invoker::ProcessManager.new }
 
   describe '#start_process_or_group_by_name' do
-    it 'finds processes by group or process name and starts them' do
+    it 'finds processes by process or group name and starts them' do
       processes_to_start = [
         OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
         OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
       ]
+
       invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_start)
       process_manager.expects(:start_process_by_name).with('postgres')
       process_manager.expects(:start_process_by_name).with('redis')
@@ -31,40 +32,77 @@ describe Invoker::ProcessManager do
     end
   end
 
+  describe '#stop_process_or_group_by_name' do
+    it 'finds processes by process or group name and stops them' do
+      processes_to_stop = [
+        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
+        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
+      ]
+
+      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_stop)
+      process_manager.expects(:stop_process).with('postgres', stop_signal: 'TERM')
+      process_manager.expects(:stop_process).with('redis', stop_signal: 'TERM')
+      process_manager.stop_process_or_group_by_name('db', stop_signal: 'TERM')
+    end
+  end
+
   describe "#stop_process" do
-    let(:message) { MM::Remove.new(options) }
     describe "when a worker is found" do
       before do
         process_manager.workers.expects(:[]).returns(OpenStruct.new(:pid => "bogus"))
       end
 
-      describe "if a signal is specified" do
-        let(:options) { { process_name: 'bogus', signal: 'HUP' } }
+      describe "if a stop signal is specified" do
         it "should use that signal to kill the worker" do
-          process_manager.expects(:process_kill).with("bogus", "HUP").returns(true)
-          expect(process_manager.stop_process(message)).to be_truthy
+          process_name, stop_signal = 'bogus', 'HUP'
+
+          process_manager.expects(:process_kill).with(process_name, stop_signal).returns(true)
+          expect(process_manager.stop_process(process_name, stop_signal: stop_signal)).to be_truthy
         end
       end
 
-      describe "if no signal is specified" do
-        let(:options) { { process_name: 'bogus' } }
+      describe "if no stop signal is specified" do
         it "should use INT signal" do
-          process_manager.expects(:process_kill).with("bogus", "INT").returns(true)
-          expect(process_manager.stop_process(message)).to be_truthy
+          process_name = 'bogus'
+
+          process_manager.expects(:process_kill).with(process_name, 'INT').returns(true)
+          expect(process_manager.stop_process(process_name)).to be_truthy
+        end
+
+        context 'stop signal is nil' do
+          it 'uses INT signal' do
+            process_name = 'bogus'
+
+            process_manager.expects(:process_kill).with(process_name, 'INT').returns(true)
+            expect(process_manager.stop_process(process_name, stop_signal: nil)).to be_truthy
+          end
         end
       end
     end
 
     describe "when no worker is found" do
-      let(:options) { { process_name: 'bogus', signal: 'HUP' } }
       before do
         process_manager.workers.expects(:[]).returns(nil)
       end
 
       it "should not kill anything" do
         process_manager.expects(:process_kill).never
-        process_manager.stop_process(message)
+        process_manager.stop_process('bogus')
       end
+    end
+  end
+
+  describe '#restart_process_or_group_by_name' do
+    it 'finds processes by process or group name and restarts them' do
+      processes_to_restart = [
+        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
+        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
+      ]
+
+      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_restart)
+      process_manager.expects(:restart_process).with('postgres', stop_signal: 'TERM')
+      process_manager.expects(:restart_process).with('redis', stop_signal: 'TERM')
+      process_manager.restart_process_or_group_by_name('db', stop_signal: 'TERM')
     end
   end
 

--- a/spec/invoker/process_manager_spec.rb
+++ b/spec/invoker/process_manager_spec.rb
@@ -3,20 +3,6 @@ require "spec_helper"
 describe Invoker::ProcessManager do
   let(:process_manager) { Invoker::ProcessManager.new }
 
-  describe '#start_process_or_group_by_name' do
-    it 'finds processes by process or group name and starts them' do
-      processes_to_start = [
-        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
-        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
-      ]
-
-      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_start)
-      process_manager.expects(:start_process_by_name).with('postgres')
-      process_manager.expects(:start_process_by_name).with('redis')
-      process_manager.start_process_or_group_by_name('db')
-    end
-  end
-
   describe "#start_process_by_name" do
     it "should find command by label and start it, if found" do
       invoker_config.stubs(:processes).returns([OpenStruct.new(:label => "resque", :cmd => "foo", :dir => "bar")])
@@ -29,20 +15,6 @@ describe Invoker::ProcessManager do
     it "should not start already running process" do
       process_manager.workers.expects(:[]).returns(OpenStruct.new(:pid => "bogus"))
       expect(process_manager.start_process_by_name("resque")).to be_falsey
-    end
-  end
-
-  describe '#stop_process_or_group_by_name' do
-    it 'finds processes by process or group name and stops them' do
-      processes_to_stop = [
-        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
-        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
-      ]
-
-      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_stop)
-      process_manager.expects(:stop_process).with('postgres', stop_signal: 'TERM')
-      process_manager.expects(:stop_process).with('redis', stop_signal: 'TERM')
-      process_manager.stop_process_or_group_by_name('db', stop_signal: 'TERM')
     end
   end
 
@@ -93,20 +65,6 @@ describe Invoker::ProcessManager do
         process_manager.expects(:process_kill).never
         process_manager.stop_process('bogus')
       end
-    end
-  end
-
-  describe '#restart_process_or_group_by_name' do
-    it 'finds processes by process or group name and restarts them' do
-      processes_to_restart = [
-        OpenStruct.new(:label => "postgres", :cmd => "foo", :dir => "bar", :group => "db"),
-        OpenStruct.new(:label => "redis", :cmd => "foo", :dir => "bar", :group => "db")
-      ]
-
-      invoker_config.expects(:processes_by_group_or_name).with('db').returns(processes_to_restart)
-      process_manager.expects(:restart_process).with('postgres', stop_signal: 'TERM')
-      process_manager.expects(:restart_process).with('redis', stop_signal: 'TERM')
-      process_manager.restart_process_or_group_by_name('db', stop_signal: 'TERM')
     end
   end
 


### PR DESCRIPTION
I've tried adding support for groups. Here's an example invoker.ini

```
[memcached]
command = /usr/local/opt/memcached/bin/memcached
disable_autorun = true
group = db

[postgres]
command = /usr/local/Cellar/postgresql/9.3.5_1/bin/postgres -D /usr/local/var/postgres
group = db
disable_autorun = true
stop_signal = TERM

[redis]
command = redis-server /usr/local/etc/redis.conf
disable_autorun = true
group = db
```

To start all processes of db group, run

```
invoker add db
```

To stop all processes of db group, run

```
invoker remove db
```

To restart all process of db group, run

```
invoker reload db
```

The pull handles groups at the ipc command level. I haven't any touched start/stop/restart code. When trying to test this feature, I ran into an issue where invoker wasn't tracking processes correctly. Here's an example where grep says memcached is no longer running, however invoker shows a pid of 4315

```
~/code/invoker (groups)% bin/invoker add db
~/code/invoker (groups)% bin/invoker list
  +-----+------+--------------+---------------------------------------------+
  | dir | pid  | process_name | shell_command                               |
  +-----+------+--------------+---------------------------------------------+
  |     | 4315 | memcached    | /usr/local/opt/memcached/bin/memcached      |
  |     | 4316 | postgres     | /usr/local/Cellar/postgresql/9.3.5_1/bin/.. |
  |     | 4317 | redis        | redis-server /usr/local/etc/redis.conf      |
  +-----+------+--------------+---------------------------------------------+
~/code/invoker (groups)% ps -ef | grep 'memcached\|postgres\|redis'
  502  4319  4316   0  1:54AM ??         0:00.00 postgres: checkpointer process
  502  4320  4316   0  1:54AM ??         0:00.00 postgres: writer process
  502  4321  4316   0  1:54AM ??         0:00.00 postgres: wal writer process
  502  4322  4316   0  1:54AM ??         0:00.00 postgres: autovacuum launcher process
  502  4323  4316   0  1:54AM ??         0:00.00 postgres: stats collector process
  502  4315  4179   0  1:54AM ttys000    0:00.01 /usr/local/opt/memcached/bin/memcached
  502  4316  4179   0  1:54AM ttys000    0:00.05 /usr/local/Cellar/postgresql/9.3.5_1/bin/postgres -D /usr/local/var/postgres
  502  4317  4179   0  1:54AM ttys000    0:00.03 redis-server 127.0.0.1:6379
  502  4342  4184   0  1:54AM ttys002    0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=.cvs --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn memcached\|postgres\|redis
~/code/invoker (groups)% bin/invoker remove db
~/code/invoker (groups)% bin/invoker list
  +-----+-------------+--------------+---------------------------------------------+
  | dir | pid         | process_name | shell_command                               |
  +-----+-------------+--------------+---------------------------------------------+
  |     | 4315        | memcached    | /usr/local/opt/memcached/bin/memcached      |
  |     | Not Running | postgres     | /usr/local/Cellar/postgresql/9.3.5_1/bin/.. |
  |     | Not Running | redis        | redis-server /usr/local/etc/redis.conf      |
  +-----+-------------+--------------+---------------------------------------------+
~/code/invoker (groups)% ps -ef | grep 'memcached\|postgres\|redis'
  502  4394  4184   0  1:55AM ttys002    0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=.cvs --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn memcached\|postgres\|redis
~/code/invoker (groups)%
```

``````
~/code/invoker (groups)% bin/invoker start invoker.ini
You can enable OSX notification for processes by installing terminal-notifier gem
redis : 4317:M 19 Jun 01:54:44.265 * Increased maximum number of open files to 10032 (it was originally set to 4864).
redis :                 _._
redis :            _.-``__ ''-._
redis :       _.-``    `.  `_.  ''-._           Redis 3.0.0 (00000000/0) 64 bit
redis :   .-`` .-```.  ```\/    _.,_ ''-._
redis :  (    '      ,       .-`  | `,    )     Running in standalone mode
redis :  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
redis :  |    `-._   `._    /     _.-'    |     PID: 4317
redis :   `-._    `-._  `-./  _.-'    _.-'
redis :  |`-._`-._    `-.__.-'    _.-'_.-'|
redis :  |    `-._`-._        _.-'_.-'    |           http://redis.io
redis :   `-._    `-._`-.__.-'_.-'    _.-'
redis :  |`-._`-._    `-.__.-'    _.-'_.-'|
redis :  |    `-._`-._        _.-'_.-'    |
redis :   `-._    `-._`-.__.-'_.-'    _.-'
redis :       `-._    `-.__.-'    _.-'
redis :           `-._        _.-'
redis :               `-.__.-'
redis :
redis : 4317:M 19 Jun 01:54:44.272 # Server started, Redis version 3.0.0
redis : 4317:M 19 Jun 01:54:44.286 * DB loaded from disk: 0.013 seconds
redis : 4317:M 19 Jun 01:54:44.286 * The server is now ready to accept connections on port 6379
postgres : LOG:  database system was shut down at 2015-06-19 00:23:13 IST
postgres : LOG:  database system is ready to accept connections
postgres : LOG:  autovacuum launcher started
Removing memcached with signal INT
Removing postgres with signal TERM
Removing redis with signal INT
memcached : Signal handled: Interrupt: 2.
Process with command memcached exited with status 0

postgres : LOG:  received smart shutdown request
postgres : LOG:  autovacuum launcher shutting down
postgres : LOG:  shutting down
postgres : LOG:  database system is shut down
redis : 4317:signal-handler (1434659104) Received SIGINT scheduling shutdown...
redis : 4317:M 19 Jun 01:55:04.236 # User requested shutdown...
redis : 4317:M 19 Jun 01:55:04.236 * Saving the final RDB snapshot before exiting.
redis : 4317:M 19 Jun 01:55:04.251 * DB saved on disk
redis : 4317:M 19 Jun 01:55:04.251 # Redis is now ready to exit, bye bye...

Process with command postgres exited with status 0
Process with command redis exited with status 0
``````

I've tried debugging but couldn't figure out why this was happening. Opening a WIP pull so someone else can try replicating this issue on their machines. @iffyuva Thoughts?
