### PR TITLE
Documentation Typo Fix

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,7 +57,7 @@
                   <a href="/#procfile"> Procfile support  </a>
                 </li>
                 <li>
-                  <a href="/#process"> Process managment </a>
+                  <a href="/#process"> Process management </a>
                 </li>
                 <li>
                   <a href="/#pow"> Migrating from Pow </a>


### PR DESCRIPTION
Fixes typo in documentation:

`Process managment` --> `Process management`