### PR TITLE
Support Linux Mint

### DIFF
--- a/lib/invoker/power/setup/distro/base.rb
+++ b/lib/invoker/power/setup/distro/base.rb
@@ -19,6 +19,9 @@ module Invoker
           when "Debian"
             require "invoker/power/setup/distro/debian"
             Debian.new
+          when "LinuxMint"
+            require "invoker/power/setup/distro/mint"
+            Mint.new
           else
             raise "Your selected distro is not supported by Invoker"
           end

--- a/lib/invoker/power/setup/distro/mint.rb
+++ b/lib/invoker/power/setup/distro/mint.rb
@@ -1,9 +1,9 @@
-require "invoker/power/setup/distro/debian"
+require "invoker/power/setup/distro/ubuntu"
 
 module Invoker
   module Power
     module Distro
-      class Ubuntu < Debian
+      class Mint < Ubuntu
       end
     end
   end


### PR DESCRIPTION
* Linux Mint is based on Ubuntu which is based on Debian
* fixes #143

-------------------------------------------------------------------------

Not sure if you like the approach I took with this, but I noticed the Debian/Ubuntu duplication and decided to let the code mirror the relationship between the distros while still allowing for individial customization should the need arise.

I could also go back to my initial fix or make the simplest possible thing:

          when "Debian", "Ubuntu", "LinuxMint"
            require "invoker/power/setup/distro/debian"
            Debian.new

and then individual code can be added when needed. 

Your call :)

Tobi