### PR TITLE
Add a cli option to specify backend services host if they are not running locally

### DIFF
--- a/lib/invoker.rb
+++ b/lib/invoker.rb
@@ -37,6 +37,7 @@ module Invoker
   class << self
     attr_accessor :config, :tail_watchers, :commander
     attr_accessor :dns_cache, :daemonize
+    attr_accessor :backend_host
 
     alias_method :daemonize?, :daemonize
 

--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -34,10 +34,15 @@ module Invoker
       type: :boolean,
       banner: "Daemonize the server into the background",
       aliases: [:d]
+    option :backend_host,
+      type: :string,
+      banner: "Host to be used for backend services if they are not running locally. e.g. docker container services in Mac OS X",
+      aliases: [:h]
     def start(file)
       Invoker.setup_config_location
       port = options[:port] || 9000
       Invoker.daemonize = options[:daemon]
+      Invoker.backend_host = options[:backend_host]
       Invoker.load_invoker_config(file, port)
       warn_about_terminal_notifier
       warn_about_old_configuration

--- a/lib/invoker/power/balancer.rb
+++ b/lib/invoker/power/balancer.rb
@@ -71,7 +71,7 @@ module Invoker
 
         dns_check_response = UrlRewriter.new.select_backend_config(headers['Host'])
         if dns_check_response && dns_check_response.port
-          connection.server(session, host: '0.0.0.0', port: dns_check_response.port)
+          connection.server(session, host: backend_host, port: dns_check_response.port)
         else
           return_error_page(404)
           http_parser.reset
@@ -103,6 +103,10 @@ module Invoker
         end
         @backend_data = false
         connection.close_connection_after_writing if backend == session
+      end
+
+      def backend_host
+        Invoker.backend_host || '0.0.0.0'
       end
 
       private

--- a/spec/invoker/power/balancer_spec.rb
+++ b/spec/invoker/power/balancer_spec.rb
@@ -19,4 +19,16 @@ describe Invoker::Power::Balancer do
       @balancer.headers_received(headers)
     end
   end
+
+  describe "#backend_host" do
+    it "should return localhost as default when backend host is not configured" do
+      Invoker.backend_host = nil
+      expect(@balancer.backend_host).to eql("0.0.0.0")
+    end
+
+    it "should return as per configured backend host" do
+      Invoker.backend_host = "192.168.59.103"
+      expect(@balancer.backend_host).to eql("192.168.59.103")
+    end
+  end
 end


### PR DESCRIPTION
- e.g. Services running in Docker containers on Mac OS X need to be accessed via
  Docker VM IP address instead of OS X's localhost.

On Mac OS X, dockerized services are not running as localhost. They need to be accessed via Docker VM (boot2docker or Docker machine) which usually has a different IP (e.g. 192.168.59.103)

Added this cli option to specify the backend service host. So the proxy could find the correct backend service.
