### PR TITLE
Added option to pass in ip address for add_http functionality

### DIFF
--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -51,9 +51,9 @@ module Invoker
       unix_socket.send_command('add', process_name: name)
     end
 
-    desc "add_http process_name port", "Add an external http process to Invoker DNS server"
-    def add_http(name, port)
-      unix_socket.send_command('add_http', process_name: name, port: port)
+    desc "add_http process_name port [IP]", "Add an external http process to Invoker DNS server"
+    def add_http(name, port, ip = nil)
+      unix_socket.send_command('add_http', process_name: name, port: port, ip: ip)
     end
 
     desc "tail process1 process2", "Tail a particular process"

--- a/lib/invoker/dns_cache.rb
+++ b/lib/invoker/dns_cache.rb
@@ -16,8 +16,8 @@ module Invoker
       @dns_mutex.synchronize { dns_data[process_name] }
     end
 
-    def add(name, port)
-      @dns_mutex.synchronize { dns_data[name] = { 'port' => port } }
+    def add(name, port, ip = nil)
+      @dns_mutex.synchronize { dns_data[name] = { 'port' => port, 'ip' => ip } }
     end
   end
 end

--- a/lib/invoker/ipc/add_http_command.rb
+++ b/lib/invoker/ipc/add_http_command.rb
@@ -2,7 +2,7 @@ module Invoker
   module IPC
     class AddHttpCommand < BaseCommand
       def run_command(message_object)
-        Invoker.dns_cache.add(message_object.process_name, message_object.port)
+        Invoker.dns_cache.add(message_object.process_name, message_object.port, message_object.ip)
         true
       end
     end

--- a/lib/invoker/ipc/dns_check_command.rb
+++ b/lib/invoker/ipc/dns_check_command.rb
@@ -6,7 +6,8 @@ module Invoker
 
         dns_check_response = Invoker::IPC::Message::DnsCheckResponse.new(
           process_name: message_object.process_name,
-          port: process_detail ? process_detail['port'] : nil
+          port: process_detail ? process_detail['port'] : nil,
+          ip: process_detail && process_detail['ip'] ? process_detail['ip'] : '0.0.0.0'
         )
         send_data(dns_check_response)
         true

--- a/lib/invoker/ipc/message.rb
+++ b/lib/invoker/ipc/message.rb
@@ -118,7 +118,7 @@ module Invoker
 
       class AddHttp < Base
         include Serialization
-        message_attributes :process_name, :port
+        message_attributes :process_name, :port, :ip
       end
 
       class Reload < Base
@@ -151,7 +151,7 @@ module Invoker
 
       class DnsCheckResponse < Base
         include Serialization
-        message_attributes :process_name, :port
+        message_attributes :process_name, :port, :ip
       end
 
       class Ping < Base

--- a/lib/invoker/power/balancer.rb
+++ b/lib/invoker/power/balancer.rb
@@ -71,7 +71,7 @@ module Invoker
 
         dns_check_response = UrlRewriter.new.select_backend_config(headers['Host'])
         if dns_check_response && dns_check_response.port
-          connection.server(session, host: '0.0.0.0', port: dns_check_response.port)
+          connection.server(session, host: dns_check_response.ip, port: dns_check_response.port)
         else
           return_error_page(404)
           http_parser.reset

--- a/lib/invoker/version.rb
+++ b/lib/invoker/version.rb
@@ -43,5 +43,5 @@ module Invoker
       Version.new(next_splits.join('.'))
     end
   end
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/spec/invoker/ipc/client_handler_spec.rb
+++ b/spec/invoker/ipc/client_handler_spec.rb
@@ -35,7 +35,17 @@ describe Invoker::IPC::ClientHandler do
   describe "add_http command" do
     let(:message_object) { MM::AddHttp.new(process_name: 'foo', port: 9000)}
     it "adds the process name and port to dns cache" do
-      invoker_dns_cache.expects(:add).with('foo', 9000)
+      invoker_dns_cache.expects(:add).with('foo', 9000, nil)
+      client_socket.string = message_object.encoded_message
+
+     client.read_and_execute
+    end
+  end
+
+  describe "add_http command with optional ip" do
+    let(:message_object) { MM::AddHttp.new(process_name: 'foo', port: 9000, ip: '192.168.0.1')}
+    it "adds the process name, port and host ip to dns cache" do
+      invoker_dns_cache.expects(:add).with('foo', 9000, '192.168.0.1')
       client_socket.string = message_object.encoded_message
 
      client.read_and_execute


### PR DESCRIPTION
Added option to pass in ip address for add_http functionality for adhoc services that are not running locally. We are running some services from virtual machines with different ip's.

For example I have elasticsearch running in a docker container via Docker Machine:
```
dm env ksrdev
export DOCKER_TLS_VERIFY="1"
export DOCKER_HOST="tcp://192.168.99.100:2376"
export DOCKER_CERT_PATH="/Users/paulcoates/.docker/machine/machines/ksrdev"
export DOCKER_MACHINE_NAME="ksrdev"
```

Notice the DOCKER_HOST ip is a private ip but not localhost (0.0.0.0.0). I don't need Invoker to manage the Elasticsearch running via Docker but I would like to add the dns entry to the Invoker DNS cache for the convenience of being able to access the interface with http://elasticsearch.dev. The current implementation of Invoker assumes processes are running on 0.0.0.0.

```
> invoker add_http elasticsearch 9200
> wget http://elasticsearch.dev
--2015-09-21 09:05:17--  http://elasticsearch.dev/
Resolving elasticsearch.dev... 127.0.0.1
Connecting to elasticsearch.dev|127.0.0.1|:80... connected.
HTTP request sent, awaiting response... No data received.
Retrying.

--2015-09-21 09:05:18--  (try: 2)  http://elasticsearch.dev/
Connecting to elasticsearch.dev|127.0.0.1|:80... failed: Connection refused.
Resolving elasticsearch.dev... 127.0.0.1
Connecting to elasticsearch.dev|127.0.0.1|:80... failed: Connection refused.
```
Connection refused since Invoker mapped the url to 0.0.0.0:9200. With this PR we can pass in an optional ip address to the Invoker add_http command for services running locally on a different ip then 0.0.0.0. For example:

```
> invoker add_http elasticsearch 9200 192.168.99.100
> wget http://elasticsearch.dev
--2015-09-21 09:19:31--  http://elasticsearch.dev/
Resolving elasticsearch.dev... 127.0.0.1
Connecting to elasticsearch.dev|127.0.0.1|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 297 [application/json]
Saving to: 'index.html'

index.html                           100%[======================================================================>]     297  --.-KB/s   in 0s

2015-09-21 09:19:31 (14.2 MB/s) - 'index.html' saved [297/297]
```

Now we were able to successfully hit http://elasticsearch.dev with wget.