### PR TITLE
start invoker at a port specified from cli

### DIFF
--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -7,9 +7,15 @@ module Invoker
       attr_accessor :processes, :power_config
       attr_reader :filename
 
+      # initialize takes a port form cli and decrements it by 1 and sets the
+      # instance variable @port. This port value is used as the environment
+      # variable $PORT mentioned inside invoker.ini. When method pick_port gets
+      # fired it increments the value of port by 1, subsequently when pick_port
+      # again gets fired, for another command, it will again increment port
+      # value by 1, that way generating different ports for different commands.
       def initialize(filename, port)
         @filename = filename
-        @port = port
+        @port = port - 1
         @processes = load_config
         if Invoker.can_run_balancer?
           @power_config = Invoker::Power::Config.load_config()
@@ -82,7 +88,7 @@ module Invoker
 
       def pick_port(section)
         if section['command'] =~ PORT_REGEX
-          @port
+          @port += 1
         elsif section['port']
           section['port']
         else

--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -82,7 +82,7 @@ module Invoker
 
       def pick_port(section)
         if section['command'] =~ PORT_REGEX
-          @port += 1
+          @port
         elsif section['port']
           section['port']
         else

--- a/spec/invoker/config_spec.rb
+++ b/spec/invoker/config_spec.rb
@@ -79,13 +79,13 @@ command = ls
         config = Invoker::Parsers::Config.new(file.path, 9000)
         command1 = config.processes.first
 
-        expect(command1.port).to eq(9001)
-        expect(command1.cmd).to match(/9001/)
+        expect(command1.port).to eq(9000)
+        expect(command1.cmd).to match(/9000/)
 
         command2 = config.processes[1]
 
-        expect(command2.port).to eq(9002)
-        expect(command2.cmd).to match(/9002/)
+        expect(command2.port).to eq(9000)
+        expect(command2.cmd).to match(/9000/)
 
         command2 = config.processes[2]
 
@@ -118,8 +118,8 @@ command = ls
         config = Invoker::Parsers::Config.new(file.path, 9000)
         command1 = config.processes.first
 
-        expect(command1.port).to eq(9001)
-        expect(command1.cmd).to match(/9001/)
+        expect(command1.port).to eq(9000)
+        expect(command1.cmd).to match(/9000/)
 
         command2 = config.processes[1]
 
@@ -162,7 +162,7 @@ web: bundle exec rails s -p $PORT
         config = Invoker::Parsers::Config.new("/tmp/Procfile", 9000)
         command1 = config.processes.first
 
-        expect(command1.port).to eq(9001)
+        expect(command1.port).to eq(9000)
         expect(command1.cmd).to match(/bundle exec rails/)
       ensure
         File.delete("/tmp/Procfile")
@@ -183,7 +183,7 @@ web: bundle exec rails s -p $PORT
 
         expect(dns_cache.dns_data).to_not be_empty
         expect(dns_cache.dns_data['web']).to_not be_empty
-        expect(dns_cache.dns_data['web']['port']).to eql 9001
+        expect(dns_cache.dns_data['web']['port']).to eql 9000
       ensure
         File.delete("/tmp/Procfile")
       end

--- a/spec/invoker/config_spec.rb
+++ b/spec/invoker/config_spec.rb
@@ -84,8 +84,8 @@ command = ls
 
         command2 = config.processes[1]
 
-        expect(command2.port).to eq(9000)
-        expect(command2.cmd).to match(/9000/)
+        expect(command2.port).to eq(9001)
+        expect(command2.cmd).to match(/9001/)
 
         command2 = config.processes[2]
 


### PR DESCRIPTION
Currently invoker accepts a port from cli, increments it by 1, and then starts the process at that port.

```
invoker start ./invoker.ini -d --port 9000
```

```
ivg : Puma starting in single mode...
ivg : * Version 2.12.2 (ruby 2.2.3-p173), codename: Plutonian Photo Shoot
ivg : * Min threads: 0, max threads: 16
ivg : * Environment: development
ivg : * Listening on tcp://0.0.0.0:9001
ivg : Use Ctrl-C to stop
```
This deteres a user from running invoker on a port of her choice.
