### PR TITLE
show port on "invoker list" command

### DIFF
--- a/lib/invoker/ipc/message.rb
+++ b/lib/invoker/ipc/message.rb
@@ -136,7 +136,7 @@ module Invoker
 
       class Process < Base
         include Serialization
-        message_attributes :process_name, :shell_command, :dir, :pid
+        message_attributes :process_name, :shell_command, :dir, :pid, :port
       end
 
       class Remove < Base

--- a/lib/invoker/ipc/message/list_response.rb
+++ b/lib/invoker/ipc/message/list_response.rb
@@ -16,8 +16,10 @@ module Invoker
           process_array = []
           Invoker.config.processes.each do |process|
             worker_attrs = {
-              :shell_command => process.cmd, :process_name => process.label,
-              :dir => process.dir
+              shell_command: process.cmd,
+              process_name: process.label,
+              dir: process.dir,
+              port: process.port
             }
             if worker = workers[process.label]
               worker_attrs.update(pid: worker.pid)

--- a/lib/invoker/process_printer.rb
+++ b/lib/invoker/process_printer.rb
@@ -26,6 +26,7 @@ module Invoker
 
       hash_with_colors['dir'] = colored_string(process.dir, color)
       hash_with_colors['pid'] = colored_string(process.pid || 'Not Running', color)
+      hash_with_colors['port'] = colored_string(process.port, color)
       hash_with_colors['shell_command'] = colored_string(process.shell_command, color)
       hash_with_colors['process_name'] = colored_string(process.process_name, color)
       hash_with_colors

--- a/spec/invoker/ipc/message/list_response_spec.rb
+++ b/spec/invoker/ipc/message/list_response_spec.rb
@@ -4,8 +4,10 @@ describe MM::ListResponse do
   context "serializing a response" do
     let(:process_array) do
       [
-        { shell_command: 'foo', process_name: 'foo', dir: '/tmp', pid: 100 },
-        { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200 }
+        { shell_command: 'foo', process_name: 'foo', dir: '/tmp', pid: 100,
+          port: 9000 },
+        { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200,
+          port: 9001 }
       ]
     end
 

--- a/spec/invoker/ipc/message_spec.rb
+++ b/spec/invoker/ipc/message_spec.rb
@@ -19,8 +19,10 @@ describe Invoker::IPC::Message do
     context "for nested messages" do
       let(:process_array) do
         [
-          { shell_command: 'foo', process_name: 'foo', dir: '/tmp', pid: 100 },
-          { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200 }
+          { shell_command: 'foo', process_name: 'foo', dir: '/tmp', pid: 100,
+            port: 9000 },
+          { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200,
+            port: 9001 }
         ]
       end
 
@@ -33,8 +35,10 @@ describe Invoker::IPC::Message do
 
       it "should report not equal for different objects" do
         another_process_array = [
-          { shell_command: 'baz', process_name: 'foo', dir: '/tmp', pid: 100 },
-          { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200 }
+          { shell_command: 'baz', process_name: 'foo', dir: '/tmp', pid: 100,
+            port: 9000 },
+          { shell_command: 'bar', process_name: 'bar', dir: '/tmp', pid: 200,
+            port: 9001 }
         ]
 
         m2 = MM::ListResponse.new(processes: another_process_array)


### PR DESCRIPTION
This is to show port number of a process(if available) when "invoker
list" command is fired. This could be helpful when we do not mention a
specific port in .ini file, let invoker handle it and then need to
access the port, e.g access the process in "localhost:port" domain.