### PR TITLE
Add notifications for Linux using libnotify

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency("facter", "~> 2.2")
   s.add_dependency("http-parser-lite", "~> 0.6")
   s.add_dependency("dotenv", "~> 1.0.2")
+  s.add_dependency("libnotify", "~> 0.9.1")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")
   s.add_development_dependency("rake")

--- a/lib/invoker.rb
+++ b/lib/invoker.rb
@@ -9,7 +9,6 @@ require "json"
 require "rainbow"
 require "rainbow/ext/string"
 require "etc"
-require "libnotify"
 
 require "invoker/version"
 require "invoker/logger"
@@ -122,6 +121,7 @@ module Invoker
     end
 
     def notify_with_libnotify(message)
+      require "libnotify"
       Libnotify.show(body: message, summary: "Invoker", timeout: 2.5)
     rescue StandardError => error
       Invoker::Logger.puts "Failed to show notification: #{error}"


### PR DESCRIPTION
This change will (try to) show a desktop notification using the libnotify gem on Linux.
If it fails, the error will be logged but not raised.