### PR TITLE
Replace rinetd with socat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ invoker.ini
 config/
 *.gem
 pkg/
-*.ini
 tags
 .rvmrc
 vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  RunRailsCops: false
   Excludes:
     - db/**
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 2.0.0
   - 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
+  - 2.3.0
 
 script: bundle exec rake spec
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.3
+
+MAINTAINER hemant@codemancers.com
+
+RUN apt-get update && apt-get -y install dnsmasq socat
+
+ADD . /invoker
+RUN cd /invoker && bundle
+CMD cd /invoker && bundle exec rake spec

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,4 @@ MAINTAINER hemant@codemancers.com
 
 RUN apt-get update && apt-get -y install dnsmasq socat
 
-ADD . /invoker
-RUN cd /invoker && bundle
-CMD cd /invoker && bundle exec rake spec
+CMD cd /invoker && bundle install --path vendor/ && bundle exec rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,8 @@ RSpec::Core::RakeTask.new
 
 task :default => :spec
 task :test => :spec
+
+desc "run specs inside docker"
+task :docker_spec do
+  system("docker run -t invoker-ruby")
+end

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,11 @@ RSpec::Core::RakeTask.new
 task :default => :spec
 task :test => :spec
 
+current_directory = File.expand_path(File.dirname(__FILE__))
+
 desc "run specs inside docker"
 task :docker_spec do
-  system("docker run -t invoker-ruby")
+  system("docker build -t invoker-ruby . ")
+  system("docker run --name invoker-rspec -v #{current_directory}:/invoker -t invoker-ruby")
+  system("docker rm invoker-rspec")
 end

--- a/examples/hello_sinatra.rb
+++ b/examples/hello_sinatra.rb
@@ -1,0 +1,26 @@
+# myapp.rb
+require 'sinatra'
+
+get '/' do
+  'Hello world!'
+end
+
+get "/emacs" do
+  redirect to("/vim")
+end
+
+get "/vim" do
+  "vim rules"
+end
+
+
+post '/foo' do
+  puts request.env
+  "done"
+end
+
+
+post "/api/v1/datapoints" do
+  puts request.env
+  "done"
+end

--- a/examples/sample.ini
+++ b/examples/sample.ini
@@ -1,0 +1,3 @@
+[rails]
+directory = /home/hulk/snippets/ruby
+command = ruby hello_sinatra.rb -p $PORT

--- a/examples/sample.ini
+++ b/examples/sample.ini
@@ -1,3 +1,3 @@
 [rails]
-directory = /home/hulk/snippets/ruby
+directory = .
 command = ruby hello_sinatra.rb -p $PORT

--- a/lib/invoker/power/setup/distro/arch.rb
+++ b/lib/invoker/power/setup/distro/arch.rb
@@ -3,13 +3,10 @@ module Invoker
     module Distro
       class Arch < Base
         def install_required_software
-          system("pacman -S --needed --noconfirm dnsmasq")
+          system("pacman -S --needed --noconfirm dnsmasq socat")
           system("mkdir -p /etc/dnsmasq.d")
           unless File.open("/etc/dnsmasq.conf").each_line.any? { |line| line.chomp == "conf-dir=/etc/dnsmasq.d" }
             File.open("/etc/dnsmasq.conf", "a") {|f| f.write("conf-dir=/etc/dnsmasq.d") }
-          end
-          unless system("ls /usr/bin/rinetd > /dev/null 2>&1")
-            fail "You'll need to install rinetd from the AUR in order to continue"
           end
         end
       end

--- a/lib/invoker/power/setup/distro/base.rb
+++ b/lib/invoker/power/setup/distro/base.rb
@@ -3,8 +3,8 @@ module Invoker
     module Distro
       class Base
         RESOLVER_FILE = "/etc/dnsmasq.d/dev-tld"
-        SOCAT_SHELLSCRIPT = "files/invoker_forwarder.sh"
-        SOCAT_SYSTEMD = "files/socat_invoker.service"
+        SOCAT_SHELLSCRIPT = "/usr/bin/invoker_forwarder.sh"
+        SOCAT_SYSTEMD = "/etc/systemd/system/socat_invoker.service"
 
         def self.distro_installer
           case Facter[:operatingsystem].value

--- a/lib/invoker/power/setup/distro/base.rb
+++ b/lib/invoker/power/setup/distro/base.rb
@@ -3,7 +3,8 @@ module Invoker
     module Distro
       class Base
         RESOLVER_FILE = "/etc/dnsmasq.d/dev-tld"
-        RINETD_FILE = "/etc/rinetd.conf"
+        SOCAT_SHELLSCRIPT = "files/invoker_forwarder.sh"
+        SOCAT_SYSTEMD = "files/socat_invoker.service"
 
         def self.distro_installer
           case Facter[:operatingsystem].value
@@ -22,6 +23,9 @@ module Invoker
           when "LinuxMint"
             require "invoker/power/setup/distro/mint"
             Mint.new
+          when "OpenSuSE"
+            require "invoker/power/setup/distro/opensuse"
+            Opensuse.new
           else
             raise "Your selected distro is not supported by Invoker"
           end
@@ -31,8 +35,12 @@ module Invoker
           RESOLVER_FILE
         end
 
-        def rinetd_file
-          RINETD_FILE
+        def socat_script
+          SOCAT_SHELLSCRIPT
+        end
+
+        def socat_systemd
+          SOCAT_SYSTEMD
         end
 
         # Install required software
@@ -41,13 +49,10 @@ module Invoker
         end
 
         def restart_services
-          if Facter[:systemctl] == "true"
-            system("systemctl restart rinetd")
-            system("systemctl restart dnsmasq")
-          else
-            system("service rinetd restart")
-            system("service dnsmasq restart")
-          end
+          system("systemctl enable socat_invoker.service")
+          system("systemctl enable dnsmasq")
+          system("systemctl start socat_invoker.service")
+          system("systemctl restart dnsmasq")
         end
       end
     end

--- a/lib/invoker/power/setup/distro/opensuse.rb
+++ b/lib/invoker/power/setup/distro/opensuse.rb
@@ -1,9 +1,9 @@
 module Invoker
   module Power
     module Distro
-      class Debian < Base
+      class Opensuse < Base
         def install_required_software
-          system("apt-get --assume-yes install dnsmasq socat")
+          system("zypper install -l dnsmasq socat")
         end
       end
     end

--- a/lib/invoker/power/setup/distro/redhat.rb
+++ b/lib/invoker/power/setup/distro/redhat.rb
@@ -3,13 +3,7 @@ module Invoker
     module Distro
       class Redhat < Base
         def install_required_software
-          system("yum --assumeyes install dnsmasq rinetd")
-        end
-
-        def restart_services
-          system("systemctl enable rinetd")
-          system("service rinetd restart")
-          system("service dnsmasq restart")
+          system("yum --assumeyes install dnsmasq socat")
         end
       end
     end

--- a/lib/invoker/power/setup/files/invoker_forwarder.sh.erb
+++ b/lib/invoker/power/setup/files/invoker_forwarder.sh.erb
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+KillJobs() {
+    for job in $(jobs -p); do
+        kill -s SIGTERM $job > /dev/null 2>&1 || (sleep 10 && kill -9 $job > /dev/null 2>&1 &)
+    done
+}
+
+# Whatever you need to clean here
+trap KillJobs SIGINT SIGTERM EXIT
+
+/usr/bin/socat TCP-LISTEN:80,reuseaddr,fork TCP:0.0.0.0:<%= http_port %>&
+pid1=$!
+/usr/bin/socat TCP-LISTEN:443,reuseaddr,fork TCP:0.0.0.0:<%= https_port %>&
+pid2=$!
+wait $pid1 $pid2
+wait $pid1 $pid2

--- a/lib/invoker/power/setup/files/socat_invoker.service
+++ b/lib/invoker/power/setup/files/socat_invoker.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Socat port forwarding service
+After=network.target
+Documentation=man:socat(1)
+
+[Service]
+ExecStart=/usr/bin/invoker_forwarder.sh
+Restart=on-success
+
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/invoker/power/setup/linux_setup.rb
+++ b/lib/invoker/power/setup/linux_setup.rb
@@ -56,7 +56,7 @@ module Invoker
       end
 
       def install_port_forwarder
-        install_forwarder_script()
+        install_forwarder_script(port_finder.http_port, port_finder.https_port)
         install_systemd_unit()
       end
 

--- a/lib/invoker/power/setup/linux_setup.rb
+++ b/lib/invoker/power/setup/linux_setup.rb
@@ -72,17 +72,17 @@ address=/dev/127.0.0.1
         script_file = File.join(File.dirname(__FILE__), "files/invoker_forwarder.sh.erb")
         script_template = File.read(script_file)
         renderer = ERB.new(script_template)
-        script_output = renderer.result()
-        File.open("/usr/bin/invoker_forwarder.sh", "w") do |fl|
+        script_output = renderer.result(binding)
+        File.open(Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT, "w") do |fl|
           fl.write(script_output)
         end
-        system("chmod +x /usr/bin/invoker_forwarder.sh")
+        system("chmod +x #{Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT}")
       end
 
       def install_systemd_unit
         unit_file = File.join(File.dirname(__FILE__), "files/socat_invoker.service")
-        FileUtils.cp(unit_file, "/etc/systemd/system/")
-        system("chmod 644 /etc/systemd/system/socat_invoker.service")
+        FileUtils.cp(unit_file, Invoker::Power::Distro::Base::SOCAT_SYSTEMD)
+        system("chmod 644 #{Invoker::Power::Distro::Base::SOCAT_SYSTEMD}")
       end
 
       def get_user_confirmation?

--- a/lib/invoker/power/setup/linux_setup.rb
+++ b/lib/invoker/power/setup/linux_setup.rb
@@ -33,8 +33,12 @@ module Invoker
       end
 
       def uninstall_invoker
-        Invoker::Logger.puts("Uninstall is not yet supported on Linux."\
-          " You can remove invoker changes by uninstalling dnsmasq and socat")
+        system("systemctl disable socat_invoker.service")
+        system("systemctl stop socat_invoker.service")
+        system("rm #{Invoker::Power::Distro::Base::SOCAT_SYSTEMD}")
+        system("rm #{Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT}")
+        drop_to_normal_user
+        Invoker::Power::Config.delete
       end
 
       private

--- a/lib/invoker/version.rb
+++ b/lib/invoker/version.rb
@@ -43,5 +43,5 @@ module Invoker
       Version.new(next_splits.join('.'))
     end
   end
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -27,7 +27,7 @@ describe Invoker::Power::LinuxSetup do
     end
   end
 
-  describe "configuring dnsmasq and rinetd" do
+  describe "configuring dnsmasq and socat" do
     before { invoker_setup.distro_installer = distro_installer }
 
     it "should create proper config file" do
@@ -46,10 +46,13 @@ describe Invoker::Power::LinuxSetup do
       expect(dnsmasq_content.strip).to_not be_empty
       expect(dnsmasq_content).to match(/dev/)
 
-      rinetd_content = File.read(distro_installer.rinetd_file)
-      expect(rinetd_content.strip).to_not be_empty
-      expect(rinetd_content.strip).to match(/#{config.https_port}/)
-      expect(rinetd_content.strip).to match(/#{config.http_port}/)
+      socat_content = File.read(distro_installer.socat_script)
+      expect(socat_content.strip).to_not be_empty
+      expect(socat_content.strip).to match(/#{config.https_port}/)
+      expect(socat_content.strip).to match(/#{config.http_port}/)
+
+      service_file = File.read(distro_installer.socat_systemd)
+      expect(service_file.strip).to_not be_empty
     end
   end
 end

--- a/spec/support/mock_setup_file.rb
+++ b/spec/support/mock_setup_file.rb
@@ -1,14 +1,18 @@
+require 'securerandom'
+
 module MockSetupFile
   def setup_mocked_config_files
     setup_invoker_config
     setup_osx_resolver_path
     setup_linux_resolver_path
+    setup_socket_path
   end
 
   def remove_mocked_config_files
     restore_invoker_config
     restore_osx_resolver_setup
     restore_linux_resolver_path
+    restore_socket_path
   end
 
   def safe_remove_file(file_location)
@@ -46,6 +50,16 @@ module MockSetupFile
 
     safe_make_directory(Invoker::Power::OsxSetup::RESOLVER_DIR)
     safe_remove_file(Invoker::Power::OsxSetup::RESOLVER_FILE)
+  end
+
+  def setup_socket_path
+    @old_socket_path = Invoker::IPC::Server::SOCKET_PATH
+    socket_uuid = SecureRandom.urlsafe_base64
+    Invoker::IPC::Server.const_set(:SOCKET_PATH, "/tmp/invoker-#{socket_uuid}")
+  end
+
+  def restore_socket_path
+    Invoker::IPC::Server.const_set(:SOCKET_PATH, @old_socket_path)
   end
 
   def setup_linux_resolver_path

--- a/spec/support/mock_setup_file.rb
+++ b/spec/support/mock_setup_file.rb
@@ -50,11 +50,19 @@ module MockSetupFile
 
   def setup_linux_resolver_path
     @old_linux_resolver = Invoker::Power::Distro::Base::RESOLVER_FILE
+    @old_socat_script = Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT
+    @old_socat_unit = Invoker::Power::Distro::Base::SOCAT_SYSTEMD
     Invoker::Power::Distro::Base.const_set(:RESOLVER_FILE, "/tmp/dev-tld")
+    Invoker::Power::Distro::Base.const_set(:SOCAT_SHELLSCRIPT, "/tmp/invoker_forwarder.sh")
+    Invoker::Power::Distro::Base.const_set(:SOCAT_SYSTEMD, "/tmp/socat_invoker.service")
   end
 
   def restore_linux_resolver_path
     safe_remove_file(Invoker::Power::Distro::Base::RESOLVER_FILE)
+    safe_remove_file(Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT)
+    safe_remove_file(Invoker::Power::Distro::Base::SOCAT_SYSTEMD)
     Invoker::Power::Distro::Base.const_set(:RESOLVER_FILE, @old_linux_resolver)
+    Invoker::Power::Distro::Base.const_set(:SOCAT_SHELLSCRIPT, @old_socat_script)
+    Invoker::Power::Distro::Base.const_set(:SOCAT_SYSTEMD, @old_socat_unit)
   end
 end

--- a/spec/support/mock_setup_file.rb
+++ b/spec/support/mock_setup_file.rb
@@ -50,15 +50,11 @@ module MockSetupFile
 
   def setup_linux_resolver_path
     @old_linux_resolver = Invoker::Power::Distro::Base::RESOLVER_FILE
-    @old_rinetd_config = Invoker::Power::Distro::Base::RINETD_FILE
     Invoker::Power::Distro::Base.const_set(:RESOLVER_FILE, "/tmp/dev-tld")
-    Invoker::Power::Distro::Base.const_set(:RINETD_FILE, "/tmp/rinetd.conf")
   end
 
   def restore_linux_resolver_path
     safe_remove_file(Invoker::Power::Distro::Base::RESOLVER_FILE)
-    safe_remove_file(Invoker::Power::Distro::Base::RINETD_FILE)
     Invoker::Power::Distro::Base.const_set(:RESOLVER_FILE, @old_linux_resolver)
-    Invoker::Power::Distro::Base.const_set(:RINETD_FILE, @old_rinetd_config)
   end
 end


### PR DESCRIPTION
This changesheet adds support for:

1. socat as port forwarder and removes rinetd. socat is available in official repositories of most distros and is rather very well supported. We could have used iptables but that path is rather cumbersome.

2. It also completely migrates to using `systemd` for managing services. AFAIK - most linux distros have moved to systemd and it is pointless to try and support many `init.d` systems.

3. Added some helpers for running tests inside docker container.