### PR TITLE
Downgrade rainbow dependency

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = %q{Something small for Process management}
   s.add_dependency("thor", "~> 0.19")
-  s.add_dependency("rainbow", "~> 2.0")
+  s.add_dependency("rainbow", "~> 2.1.0")
   s.add_dependency("iniparse", "~> 1.1")
   s.add_dependency("formatador", "~> 0.2")
   s.add_dependency("eventmachine", "~> 1.0.4")


### PR DESCRIPTION
Rainbow in latest version seems to have become a
C extension which doesn't correctly compile in
certain environments. Lets downgrade it for now.

CC @iffyuva 