### PR TITLE
Prefer Procfile.dev to Procfile

### DIFF
--- a/lib/invoker/parsers/config.rb
+++ b/lib/invoker/parsers/config.rb
@@ -53,7 +53,7 @@ module Invoker
       private
 
       def autodetect_config_file
-        Dir.glob("{invoker.ini,Procfile}").first
+        Dir.glob("{invoker.ini,Procfile.dev,Procfile}").first
       end
 
       def invalid_config_file?


### PR DESCRIPTION
Typically `Procfile.dev` is used for local development, so in my opinion, it should be used, if available, before Procfile