### PR TITLE
Add support for raw listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add support for running Invoker build in SELinux environments (https://github.com/code-mancers/invoker/pull/188)
 * Fix colors in console output (https://github.com/code-mancers/invoker/pull/192)
+* Add an option to print process listing in raw format. This enables us to see complete process list (https://github.com/code-mancers/invoker/pull/193)
 
 ## v1.5.3
 

--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -80,9 +80,17 @@ module Invoker
     end
 
     desc "list", "List all running processes"
+    option :raw,
+      type: :boolean,
+      banner: "Print process list in raw text format",
+      aliases: [:r]
     def list
       unix_socket.send_command('list') do |response_object|
-        Invoker::ProcessPrinter.new(response_object).tap { |printer| printer.print_table }
+        if options[:raw]
+          Invoker::ProcessPrinter.new(response_object).tap { |printer| printer.print_raw_text }
+        else
+          Invoker::ProcessPrinter.new(response_object).tap { |printer| printer.print_table }
+        end
       end
     end
 

--- a/lib/invoker/process_printer.rb
+++ b/lib/invoker/process_printer.rb
@@ -20,7 +20,6 @@ module Invoker
     end
 
     def print_raw_text
-      Formatador.display_line("[green]--------------------------------------[/]")
       list_response.processes.each do |process|
         Formatador.display_line("[bold]Process Name : #{process.process_name}[/]")
         Formatador.indent {
@@ -33,7 +32,6 @@ module Invoker
           Formatador.display_line("Port : #{process.port}")
           Formatador.display_line("Command : #{process.shell_command}")
         }
-        Formatador.display_line("[green]--------------------------------------[/]")
       end
     end
 

--- a/lib/invoker/process_printer.rb
+++ b/lib/invoker/process_printer.rb
@@ -19,6 +19,24 @@ module Invoker
       Formatador.display_compact_table(hash_with_colors)
     end
 
+    def print_raw_text
+      Formatador.display_line("[green]--------------------------------------[/]")
+      list_response.processes.each do |process|
+        Formatador.display_line("[bold]Process Name : #{process.process_name}[/]")
+        Formatador.indent {
+          Formatador.display_line("Dir : #{process.dir}")
+          if process.pid
+            Formatador.display_line("PID : #{process.pid}")
+          else
+            Formatador.display_line("PID : Not Running")
+          end
+          Formatador.display_line("Port : #{process.port}")
+          Formatador.display_line("Command : #{process.shell_command}")
+        }
+        Formatador.display_line("[green]--------------------------------------[/]")
+      end
+    end
+
     private
 
     def colorize_hash(process, color)


### PR DESCRIPTION
Add support for raw listing:

```
─kube_scripts/xaos_master_kube> sudo invoker list -r
  --------------------------------------
  Process Name : etcd
    Dir : 
    PID : 14558
    Port : 
    Command : /content/kube_bin/etcd --name=default --data-dir=/var/lib/etcd/default.etcd --listen-client-urls=http://0.0.0.0:4001 --listen-peer-urls=http://localhost:2380 --advertise-client-urls=http://0.0.0.0:4001
  --------------------------------------
  Process Name : api_server
    Dir : 
    PID : 14942
    Port : 
    Command : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin/kube-apiserver -v 2 $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL $KUBE_ETCD_SERVERS $KUBE_API_ADDRESS --insecure-port=8080 $KUBE_ALLOW_PRIV  $KUBE_SERVICE_ADDRESSES $KUBE_ADMISSION_CONTROL  $KUBE_API_ARGS --enable-swagger-ui=true
  --------------------------------------
  Process Name : controller
    Dir : 
    PID : 14987
    Port : 
    Command : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin/kube-controller-manager -v 2 $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL --master=http://xaos.lan:8080 $KUBE_CONTROLLER_MANAGER_ARGS
  --------------------------------------
  Process Name : scheduler
    Dir : 
    PID : 15004
    Port : 
    Command : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin/kube-scheduler -v 2 $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL --master=http://xaos.lan:8080 $KUBE_SCHEDULER_ARGS
  --------------------------------------
  Process Name : proxy
    Dir : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin
    PID : 15017
    Port : 
    Command : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin/kube-proxy $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL --master=http://xaos.lan:8080 $KUBE_PROXY_ARGS
  --------------------------------------
  Process Name : kubelet
    Dir : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin
    PID : 15182
    Port : 
    Command : /home/shared/go_projects/src/k8s.io/kubernetes/_output/bin/kubelet $KUBE_LOGTOSTDERR $KUBE_LOG_LEVEL -v 2 --api_servers=http://xaos.lan:8080 $KUBELET_ADDRESS $KUBELET_PORT $KUBELET_HOSTNAME $KUBE_ALLOW_PRIV $KUBELET_ARGS
```