### PR TITLE
Fix high cpu usage of Invoker under certain cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog since 1.5.4
 
+* Fix high cpu usage when process managed by Invoker crashes and Invoker doesn't read from its socket.
+
 
 # v1.5.4
 * Add support for running Invoker build in SELinux environments (https://github.com/code-mancers/invoker/pull/188)

--- a/lib/invoker/version.rb
+++ b/lib/invoker/version.rb
@@ -43,5 +43,5 @@ module Invoker
       Version.new(next_splits.join('.'))
     end
   end
-  VERSION = "1.5.4"
+  VERSION = "1.5.5"
 end


### PR DESCRIPTION
Not reading from a socket with event could result in that socket always being ready and can cause high cpu usage on select.

This makes sure that for disconnected/crashed process, we always drain the socket.

cc @iffyuva @kgrz 