### PR TITLE
Set default domain to .local instead of .dev

### DIFF
--- a/lib/invoker.rb
+++ b/lib/invoker.rb
@@ -146,7 +146,7 @@ module Invoker
     end
 
     def default_tld
-      'dev'
+      'local'
     end
   end
 end

--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -134,11 +134,13 @@ module Invoker
       tasks.keys + ["help"]
     end
 
+    # TODO(kgrz): the default TLD option is duplicated in both this file and
+    # lib/invoker.rb May be assign this to a constant?
     def get_tld(options)
       if options[:tld] && !options[:tld].empty?
         options[:tld]
       else
-        'dev'
+        'local'
       end
     end
 

--- a/spec/invoker/power/pf_migrate_spec.rb
+++ b/spec/invoker/power/pf_migrate_spec.rb
@@ -59,7 +59,7 @@ describe Invoker::Power::PfMigrate do
       mock_config = mock()
       mock_config.stubs(:http_port).returns(80)
       mock_config.stubs(:https_port).returns(443)
-      mock_config.stubs(:tld).returns('dev')
+      mock_config.stubs(:tld).returns('local')
       Invoker.config = mock_config
     end
 

--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -24,8 +24,8 @@ describe Invoker::Power::LinuxSetup, fakefs: true do
     FileUtils.mkdir_p(Invoker::Power::Distro::Base::RESOLVER_DIR)
   end
 
-  let(:invoker_setup) { Invoker::Power::LinuxSetup.new('dev') }
-  let(:distro_installer) { Invoker::Power::Distro::Ubuntu.new('dev') }
+  let(:invoker_setup) { Invoker::Power::LinuxSetup.new('local') }
+  let(:distro_installer) { Invoker::Power::Distro::Ubuntu.new('local') }
 
   describe "should only proceed after user confirmation" do
     before { invoker_setup.distro_installer = distro_installer }
@@ -78,7 +78,7 @@ describe Invoker::Power::LinuxSetup, fakefs: true do
 
       dnsmasq_content = File.read(distro_installer.resolver_file)
       expect(dnsmasq_content.strip).to_not be_empty
-      expect(dnsmasq_content).to match(/dev/)
+      expect(dnsmasq_content).to match(/local/)
 
       socat_content = File.read(Invoker::Power::Distro::Base::SOCAT_SHELLSCRIPT)
       expect(socat_content.strip).to_not be_empty

--- a/spec/invoker/power/url_rewriter_spec.rb
+++ b/spec/invoker/power/url_rewriter_spec.rb
@@ -8,39 +8,39 @@ describe Invoker::Power::UrlRewriter do
       @original_invoker_config = Invoker.config
 
       Invoker.config = mock
-      Invoker.config.stubs(:tld).returns("dev")
+      Invoker.config.stubs(:tld).returns("local")
     end
 
     after(:all) do
       Invoker.config = @original_invoker_config
     end
 
-    it "should match foo.dev" do
-      match = rewriter.extract_host_from_domain("foo.dev")
+    it "should match foo.local" do
+      match = rewriter.extract_host_from_domain("foo.local")
       expect(match).to_not be_empty
 
       matching_string = match[0]
       expect(matching_string).to eq("foo")
     end
 
-    it "should match foo.dev:1080" do
-      match = rewriter.extract_host_from_domain("foo.dev:1080")
+    it "should match foo.local:1080" do
+      match = rewriter.extract_host_from_domain("foo.local:1080")
       expect(match).to_not be_empty
 
       matching_string = match[0]
       expect(matching_string).to eq("foo")
     end
 
-    it "should match emacs.bar.dev" do
-      match = rewriter.extract_host_from_domain("emacs.bar.dev")
+    it "should match emacs.bar.local" do
+      match = rewriter.extract_host_from_domain("emacs.bar.local")
       expect(match).to_not be_empty
 
       expect(match[0]).to eq("emacs.bar")
       expect(match[1]).to eq("bar")
     end
 
-    it "should match hello-world.dev" do
-      match = rewriter.extract_host_from_domain("hello-world.dev")
+    it "should match hello-world.local" do
+      match = rewriter.extract_host_from_domain("hello-world.local")
       expect(match).to_not be_nil
 
       expect(match[0]).to eq("hello-world")


### PR DESCRIPTION
.dev domains are now official TLDs, and browsers are automatically
redirecting the websites to `https` via HSTS lists. This will add an
annoying warning page, not to mention clashes with actual domains.