### PR TITLE
Update documentation post #206

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,7 +32,7 @@
       <h1 class="in-logo">
         <div class="container">
           <a href="/" title="Invoker "><img src="images/logo.png" alt="Invoker"></a>
-          <a href="javascript:void(0)" onclick="window.open('https://twitter.com/share?text=Introducing Invoker 1.0 - release with runtime agnostic .dev local domains support&amp;url=http://invoker.codemancers.com/&amp;via=codemancershq', '', 'width=600, height=400')" class="social-icon"><span class="icon-t"></span></a>
+          <a href="javascript:void(0)" onclick="window.open('https://twitter.com/share?text=Introducing Invoker 1.0 - release with runtime agnostic .local domains support&amp;url=http://invoker.codemancers.com/&amp;via=codemancershq', '', 'width=600, height=400')" class="social-icon"><span class="icon-t"></span></a>
 
           <a href="javascript:void(0)" onclick="window.open('https://plusone.google.com/_/+1/confirm?hl=en&amp;url=http://invoker.codemancers.com/', '', 'width=600, height=250')" class="social-icon"><span class="icon-g"></span></a>
         </div>
@@ -48,7 +48,7 @@
               <a href="/"> Getting Started </a>
               <ul class="getting-started-list">
                 <li>
-                  <a href="/#tld"> .dev local domain </a>
+                  <a href="/#tld"> .local domain </a>
                 </li>
                 <li>
                   <a href="/#https_support"> Https Support </a>

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ Use it for managing multiple processes with ease.
 Use it for developing web applications on different local domains without
 `/etc/hosts` hacks.
 
-Invoker supports DNS and proxying of HTTP/HTTPS/WebSocket applications over a `.dev`
+Invoker supports DNS and proxying of HTTP/HTTPS/WebSocket applications over a `.local`
 like local TLD.
 
 <img src="images/Invoker-Infographics.svg">
@@ -21,9 +21,9 @@ like local TLD.
 A brief overview of Invoker features are:
 
 * Manage multiple dependent processes using Invoker. You can use Procfile or a INI file to define multiple processes managed by Invoker.
-* Invoker supports proxying to your HTTP application via a locally defined TLD like `.dev`.
+* Invoker supports proxying to your HTTP application via a locally defined TLD like `.local`
 * Invoker automatically supports HTTPS, Websocket for your application.
-* Any externally running HTTP application can use HTTP proxy of Invoker for access via `http://app.dev` domain.
+* Any externally running HTTP application can use HTTP proxy of Invoker for access via `http://app.local` domain.
 
 
 ## How to use it?
@@ -66,9 +66,9 @@ can also start `Invoker` by daeomonizing it, via:
 {% endhighlight %}
 
 <a name="tld"></a>
-## .dev TLD support for OSX and Linux.
+## .local TLD support for OSX and Linux.
 
-You can access http services managed by invoker via `command_label.dev` domain locally.
+You can access http services managed by invoker via `command_label.local` domain locally.
 
 To make it work though, you need to run following command, just once from anywhere:
 
@@ -116,17 +116,17 @@ command = activemq-admin start
 disable_autorun = true
 {% endhighlight %}
 
-Now these services can be accessed via `http://terminal.dev` , `http://cms.dev`
-`http://typo.dev`. You can also access them via wildcard subdomains such as `*.*.dev`.
+Now these services can be accessed via `http://terminal.local` , `http://cms.local`
+`http://typo.local`. You can also access them via wildcard subdomains such as `*.*.local`.
 
-You can also access any external http process via `.dev` DNS by running
+You can also access any external http process via `.local` DNS by running
 following command:
 
 {% highlight bash %}
 ~> invoker add_http wordpress 8080
 {% endhighlight %}
 
-Above command will make wordpress available on `wordpress.dev` even if
+Above command will make wordpress available on `wordpress.local` even if
 wordpress was original not started by Invoker. You can access any randomly
 started process via Invoker like this.
 
@@ -134,7 +134,7 @@ started process via Invoker like this.
 ## Https support
 
 Invoker uses a self-signed certificate to make all your web applications available via
-`https` as well. You absolutely don't have to do anything. Access your webapps on `https://app.dev`
+`https` as well. You absolutely don't have to do anything. Access your webapps on `https://app.local`
 and enjoy!
 
 
@@ -146,7 +146,7 @@ have been using a `Procfile` to bootstrap your development stack, you can
 keep using it with `Invoker.`
 
 The only thing to remember is, your `Procfile`
-must have `$PORT` in command - for `.dev` domain feature to work
+must have `$PORT` in command - for `.local` domain feature to work
 
 {% highlight bash %}
 rails: cd $HOME/rails_app && bundle exec rails s -p $PORT


### PR DESCRIPTION
We changed the default TLD to `.local` instead of `.dev`.