### PR TITLE
fix broken link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,7 +94,7 @@
           <div class="col-1-of-2">
             <div class="in-hire-us">
               <div>
-                <a href="http://codemancers.com/hire_us/index.html" target="_blank" class="in-btn">Hire us</a>
+                <a href="https://www.codemancers.com/contact/index.html" target="_blank" class="in-btn">Hire us</a>
                 <p>to support</p>
               </div>
               <img src="/images/logo.png" alt="Invoker ">


### PR DESCRIPTION
Currently the "hire us" link redirects to https://www.codemancers.com/contact/
![screen shot 2018-01-15 at 7 45 48 pm](https://user-images.githubusercontent.com/6086557/34946430-deb5a380-fa2c-11e7-8890-f41eb7599f8a.png)

This PR fixes this.