### PR TITLE
Don't depend on dotenv versions greater than 2.2.2

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency("uuid", "~> 2.3")
   s.add_dependency("facter", "~> 2.2")
   s.add_dependency("http-parser-lite", "~> 0.6")
-  s.add_dependency("dotenv", "~> 2.0")
+  s.add_dependency("dotenv", "~> 2.0", "<= 2.2.2")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")
   s.add_development_dependency("rake")


### PR DESCRIPTION
`Dotenv::Environment` in versions later than 2.2.2 requires a new argument upon initialization: https://github.com/bkeepers/dotenv/blob/v2.3.0/lib/dotenv/environment.rb#L7

Invoker does not pass in a second argument: https://github.com/code-mancers/invoker/blob/master/lib/invoker/process_manager.rb#L101

This is a quickfix and a better solution would probably be to pass in that second argument for version of Dotenv greater than 2.2.2


