### PR TITLE
Check if config file exists before removal on uninstall

### DIFF
--- a/lib/invoker/power/setup.rb
+++ b/lib/invoker/power/setup.rb
@@ -11,9 +11,11 @@ module Invoker
       end
 
       def self.uninstall
-        power_config = Invoker::Power::Config.load_config
-        selected_installer_klass = installer_klass
-        selected_installer_klass.new(power_config.tld).uninstall_invoker
+        if Invoker::Power::Config.has_config?
+          power_config = Invoker::Power::Config.load_config
+          selected_installer_klass = installer_klass
+          selected_installer_klass.new(power_config.tld).uninstall_invoker
+        end
       end
 
       def self.installer_klass


### PR DESCRIPTION
Fixes #195 

Changes
 - Checks if `config_file` is present before performing uninstall

Felt this could be the simple fix applicable, please to let know if any side effects are missed.
