### PR TITLE
Add Manjaro as supported distro

### DIFF
--- a/lib/invoker/power/setup/distro/base.rb
+++ b/lib/invoker/power/setup/distro/base.rb
@@ -19,7 +19,7 @@ module Invoker
           when "Fedora"
             require "invoker/power/setup/distro/redhat"
             Redhat.new(tld)
-          when "Archlinux"
+          when "Archlinux", "Manjarolinux"
             require "invoker/power/setup/distro/arch"
             Arch.new(tld)
           when "Debian"


### PR DESCRIPTION
Was facing an error that my linux distro (Manjaro) is not supported. But because it's Arch-based and Arch distro _is_ supported, I modified where distro names are checked to accept Manjaro and everything works great.