### PR TITLE
Fix build pipeline

### DIFF
--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -22,6 +22,7 @@ describe Invoker::Power::LinuxSetup, fakefs: true do
   before do
     FileUtils.mkdir_p(inv_conf_dir)
     FileUtils.mkdir_p(Invoker::Power::Distro::Base::RESOLVER_DIR)
+    Invoker.config = mock
   end
 
   let(:invoker_setup) { Invoker::Power::LinuxSetup.new('test') }
@@ -52,7 +53,6 @@ describe Invoker::Power::LinuxSetup, fakefs: true do
   describe "configuring dnsmasq and socat" do
     before(:all) do
       @original_invoker_config = Invoker.config
-      Invoker.config = mock
     end
 
     after(:all) do

--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -16,6 +16,7 @@ def mock_socat_scripts
     fl.write(socat_content)
   end
   FileUtils.mkdir_p("/usr/bin")
+  FileUtils.mkdir_p("/etc/systemd/system")
 end
 
 describe Invoker::Power::LinuxSetup, fakefs: true do

--- a/spec/invoker/power/url_rewriter_spec.rb
+++ b/spec/invoker/power/url_rewriter_spec.rb
@@ -3,12 +3,18 @@ require 'spec_helper'
 describe Invoker::Power::UrlRewriter do
   let(:rewriter) { Invoker::Power::UrlRewriter.new }
 
-  context "matching domain part of incoming request" do
-    before(:all) do
-      @original_invoker_config = Invoker.config
+  before(:all) do
+    @original_invoker_config = Invoker.config
+  end
 
-      Invoker.config = mock
-      Invoker.config.stubs(:tld).returns("test")
+  def mock_invoker_tld_as(domain)
+    Invoker.config = mock
+    Invoker.config.stubs(:tld).returns(domain)
+  end
+
+  context "matching domain part of incoming request" do
+    before(:each) do
+      mock_invoker_tld_as("test")
     end
 
     after(:all) do
@@ -47,11 +53,8 @@ describe Invoker::Power::UrlRewriter do
     end
 
     context 'user sets up a custom top level domain' do
-      before(:all) do
-        @original_invoker_config = Invoker.config
-
-        Invoker.config = mock
-        Invoker.config.stubs(:tld).returns("local")
+      before(:each) do
+        mock_invoker_tld_as("local")
       end
 
       it 'should match domain part of incoming request correctly' do

--- a/spec/invoker/power/url_rewriter_spec.rb
+++ b/spec/invoker/power/url_rewriter_spec.rb
@@ -12,13 +12,13 @@ describe Invoker::Power::UrlRewriter do
     Invoker.config.stubs(:tld).returns(domain)
   end
 
+  after(:all) do
+    Invoker.config = @original_invoker_config
+  end
+
   context "matching domain part of incoming request" do
     before(:each) do
       mock_invoker_tld_as("test")
-    end
-
-    after(:all) do
-      Invoker.config = @original_invoker_config
     end
 
     it "should match foo.test" do
@@ -63,10 +63,6 @@ describe Invoker::Power::UrlRewriter do
 
         matching_string = match[0]
         expect(matching_string).to eq("foo")
-      end
-
-      after(:all) do
-        Invoker.config = @original_invoker_config
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ MM = Invoker::IPC::Message
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.mock_framework = :mocha
+  config.mock_with :mocha
   config.include FakeFS::SpecHelpers, fakefs: true
 
   # Run specs in random order to surface order dependencies. If you find an


### PR DESCRIPTION
Have added some changes to make the specs pass. 
Changes
- Move the mocking inside context
- Manually create target system folder for specs

In `spec/invoker/power/url_rewriter_spec.rb` the `before` and `after` callbacks have been moved to root block - wondering if this is okay? I don't see much trouble though. 