### PR TITLE
Allow 'reload' to be invoked by alias 'restart'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.5.7
 * Enable Manjaro Linux support
+* Add `restart` as an alias of `reload` command (https://github.com/code-mancers/invoker/pull/229)
 
 # v1.5.6
 * Change default tld from .dev to .test (https://github.com/code-mancers/invoker/pull/208)

--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -91,6 +91,7 @@ module Invoker
       signal = options[:signal] || 'INT'
       unix_socket.send_command('reload', process_name: name, signal: signal)
     end
+    map restart: :reload
 
     desc "list", "List all running processes"
     option :raw,
@@ -131,7 +132,7 @@ module Invoker
     end
 
     def self.valid_tasks
-      tasks.keys + ["help"]
+      tasks.keys + %w(help restart)
     end
 
     # TODO(kgrz): the default TLD option is duplicated in both this file and


### PR DESCRIPTION
I always find myself typing `invoker restart process` when I actually mean `reload`. This allows `restart` to be an alias of reload.