### PR TITLE
Move label color to front of array when removing worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.5.7
 * Enable Manjaro Linux support
+* Ensure same color is re-used for next started process, which is helpful to maintain consistency when using `reload` command (https://github.com/code-mancers/invoker/pull/230)
 
 # v1.5.6
 * Change default tld from .dev to .test (https://github.com/code-mancers/invoker/pull/208)

--- a/lib/invoker/process_manager.rb
+++ b/lib/invoker/process_manager.rb
@@ -168,6 +168,9 @@ module Invoker
       if worker
         @open_pipes.delete(worker.pipe_end.fileno)
         @workers.delete(command_label)
+        # Move label color to front of array so it's reused first
+        LABEL_COLORS.delete(worker.color)
+        LABEL_COLORS.unshift(worker.color)
       end
       if trigger_event
         Invoker.commander.trigger(command_label, :worker_removed)


### PR DESCRIPTION
Ensure same color is re-used for next started process, which is helpful to maintain consistency when using `reload` command