### PR TITLE
Allow 'setup' to be invoked by alias 'install'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.5.7
 * Enable Manjaro Linux support
+* Add `install` as an alias of `setup` command (https://github.com/code-mancers/invoker/pull/232)
 
 # v1.5.6
 * Change default tld from .dev to .test (https://github.com/code-mancers/invoker/pull/208)

--- a/lib/invoker/cli.rb
+++ b/lib/invoker/cli.rb
@@ -19,6 +19,7 @@ module Invoker
     def setup
       Invoker::Power::Setup.install(get_tld(options))
     end
+    map install: :setup
 
     desc "version", "Print Invoker version"
     def version
@@ -131,7 +132,7 @@ module Invoker
     end
 
     def self.valid_tasks
-      tasks.keys + ["help"]
+      tasks.keys + %w(help install)
     end
 
     # TODO(kgrz): the default TLD option is duplicated in both this file and


### PR DESCRIPTION
The reverse command is `uninstall` so this one also makes more logical sense to me (and I find myself typing it all the time incorrectly assuming it'll run setup)