### PR TITLE
Use any dotenv 2.x version except 2.3 or 2.4

### DIFF
--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency("rubydns", "~> 0.8.5")
   s.add_dependency("uuid", "~> 2.3")
   s.add_dependency("http-parser-lite", "~> 0.6")
-  s.add_dependency("dotenv", "~> 2.0", "<= 2.2.2")
+  s.add_dependency("dotenv", "~> 2.0", "!= 2.3.0", "!= 2.4.0")
   s.add_development_dependency("rspec", "~> 3.0")
   s.add_development_dependency("mocha")
   s.add_development_dependency("rake")


### PR DESCRIPTION
The backwards-incompatibility introduced in 2.3.0 was fixed in 2.5.0
https://github.com/bkeepers/dotenv/blob/master/Changelog.md#250---june-21-2018