### PR TITLE
Relax thor version restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       rvm: ruby # Latest stable version
       script: bundle exec rspec --tag ~docker # Don't run specs with docker: true
       cache: bundler
-      # Clear out values set above for docker runs
+      # Clear out values that were set above specifically for docker runs
       env:
       before_install:
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,17 @@ services:
   - docker
 
 before_install:
-  - docker pull "$distro":latest
-  - docker run -v $PWD:/src "$distro":latest /bin/bash -c "$install && gem install bundler --no-document --no-format-executable && cd /src && bundle install && distro=$distro bundle exec rspec --tag docker"
+  - docker run -v $PWD:/src "$DISTRO":latest /bin/sh -c "$INSTALL && gem install bundler --no-document --no-format-execut able && cd /src && bundle install && DISTRO=$DISTRO bundle exec rspec --tag docker"
 
 env:
-  - distro=archlinux install='pacman -Sy --noconfirm base-devel ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
-  - distro=debian install="apt-get update; apt-get install -y build-essential ruby ruby-dev"
-  - distro=fedora install='dnf install -y gcc-c++ make redhat-rpm-config ruby ruby-devel'
-  - distro=linuxmintd/mint19.3-amd64 install="apt-get update; apt-get install -y build-essential ruby ruby-dev"
-  - distro=manjarolinux/base install='pacman -Sy --noconfirm base-devel ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
-  - distro=opensuse/leap install='zypper install -y gcc-c++ make ruby ruby-devel'
-  - distro=opensuse/tumbleweed install='zypper install -y gcc-c++ make ruby ruby-devel'
-  - distro=ubuntu install="apt-get update; apt-get install -y build-essential ruby ruby-dev"
+  - DISTRO=archlinux/base INSTALL='pacman -Sy --noconfirm base-devel libffi ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
+  - DISTRO=debian INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
+  - DISTRO=fedora INSTALL='dnf install -y gcc-c++ make redhat-rpm-config ruby ruby-devel'
+  - DISTRO=linuxmintd/mint19.3-amd64 INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
+  - DISTRO=manjarolinux/base INSTALL='pacman -Sy --noconfirm base-devel libffi ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
+  - DISTRO=opensuse/leap INSTALL='zypper install -y gcc-c++ make ruby ruby-devel'
+  - DISTRO=opensuse/tumbleweed INSTALL='zypper install -y gcc-c++ make ruby ruby-devel'
+  - DISTRO=ubuntu INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - DISTRO=archlinux/base INSTALL='pacman -Sy --noconfirm base-devel libffi ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
   - DISTRO=debian INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
   - DISTRO=fedora INSTALL='dnf install -y gcc-c++ make redhat-rpm-config ruby ruby-devel'
-  - DISTRO=linuxmintd/mint19.3-amd64 INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
+  - DISTRO=linuxmintd/mint20-amd64 INSTALL="apt-get update; apt-get install -y build-essential ruby ruby-dev"
   - DISTRO=manjarolinux/base INSTALL='pacman -Sy --noconfirm base-devel libffi ruby && PATH="$PATH:$(ruby -e "puts Gem.user_dir")/bin"'
   - DISTRO=opensuse/leap INSTALL='zypper install -y gcc-c++ make ruby ruby-devel'
   - DISTRO=opensuse/tumbleweed INSTALL='zypper install -y gcc-c++ make ruby ruby-devel'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add `install` as an alias of `setup` command (https://github.com/code-mancers/invoker/pull/232)
 * Change default process sleep duration to 0 (https://github.com/code-mancers/invoker/pull/231)
 * Add `restart` as an alias of `reload` command (https://github.com/code-mancers/invoker/pull/229)
+* Remove facter dependency (https://github.com/code-mancers/invoker/pull/236)
+* Relax dotenv dependency version restriction (https://github.com/code-mancers/invoker/pull/237)
+* Relax thor dependency version restriction (https://github.com/code-mancers/invoker/pull/238)
 
 # v1.5.6
 * Change default tld from .dev to .test (https://github.com/code-mancers/invoker/pull/208)

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'coveralls', '>= 0.8', require: false
+gem 'simplecov', require: false
 gem 'websocket-eventmachine-server', require: false
 gem 'websocket-eventmachine-client', require: false
-
-group :development do
-  gem 'pry'
-  gem 'tins', '~>1.4.0'
-  gem 'coveralls', require: false
-  gem "simplecov", require: false
-end

--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -21,10 +21,18 @@ Gem::Specification.new do |s|
   s.executables   = Dir.glob("bin/*").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.homepage = %q{http://invoker.codemancers.com}
+  s.homepage = %q{https://invoker.codemancers.com}
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
   s.summary = %q{Something small for Process management}
+
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/code-mancers/invoker/issues",
+    "changelog_uri" => "https://github.com/code-mancers/invoker/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://invoker.codemancers.com/",
+    "source_code_uri" => "https://github.com/code-mancers/invoker/tree/v#{Invoker::VERSION}",
+  }
+
   s.add_dependency("thor", "~> 0.19")
   s.add_dependency("colorize", "~> 0.8.1")
   s.add_dependency("iniparse", "~> 1.1")

--- a/invoker.gemspec
+++ b/invoker.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     "source_code_uri" => "https://github.com/code-mancers/invoker/tree/v#{Invoker::VERSION}",
   }
 
-  s.add_dependency("thor", "~> 0.19")
+  s.add_dependency("thor", ">= 0.19", "< 2")
   s.add_dependency("colorize", "~> 0.8.1")
   s.add_dependency("iniparse", "~> 1.1")
   s.add_dependency("formatador", "~> 0.2")

--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -146,8 +146,8 @@ end
 describe Invoker::Power::Distro::Base, docker: true do
   describe '.distro_installer' do
     it 'correctly recognizes the current distro' do
-      case ENV['distro']
-      when 'archlinux', 'manjarolinux/base'
+      case ENV['DISTRO']
+      when 'archlinux/base', 'manjarolinux/base'
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Arch
       when 'debian'
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Debian

--- a/spec/invoker/power/setup/linux_setup_spec.rb
+++ b/spec/invoker/power/setup/linux_setup_spec.rb
@@ -153,7 +153,7 @@ describe Invoker::Power::Distro::Base, docker: true do
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Debian
       when 'fedora'
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Redhat
-      when 'linuxmintd/mint19.3-amd64', 'ubuntu'
+      when 'linuxmintd/mint20-amd64', 'ubuntu'
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Ubuntu
       when 'opensuse/leap', 'opensuse/tumbleweed'
         expect(described_class.distro_installer('')).to be_a Invoker::Power::Distro::Opensuse

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require "pry"
 require "simplecov"
 require 'coveralls'
 require 'fakefs/spec_helpers'


### PR DESCRIPTION
It doesn't seem there was any reason to prevent using versions 1.x as the breaking changes don't affect Invoker.

Some other fixes in this PR:
* Fix broken builds for Arch/Manjaro
* Remove pry from dev dependencies
* Require newer coveralls gem versions (previously was locked to `0.7.x` due to a lock placed on the `tins` dep)
* Add some useful metadata to the gemspec