### PR TITLE
Case-insensitive Host check in the Balancer

### DIFF
--- a/lib/invoker/power/balancer.rb
+++ b/lib/invoker/power/balancer.rb
@@ -65,12 +65,14 @@ module Invoker
           return
         end
         @session = UUID.generate()
-        if !headers['Host'] || headers['Host'].empty?
+        headers = headers.transform_keys(&:downcase)
+
+        if !headers['host'] || headers['host'].empty?
           return_error_page(400)
           return
         end
 
-        dns_check_response = UrlRewriter.new.select_backend_config(headers['Host'])
+        dns_check_response = UrlRewriter.new.select_backend_config(headers['host'])
         if dns_check_response && dns_check_response.port
           connection.server(session, host: dns_check_response.ip, port: dns_check_response.port)
         else

--- a/spec/invoker/power/balancer_spec.rb
+++ b/spec/invoker/power/balancer_spec.rb
@@ -6,6 +6,37 @@ describe Invoker::Power::Balancer do
     @balancer = Invoker::Power::Balancer.new(@http_connection, "http")
   end
 
+  context "when Host field is not capitalized" do
+    before(:all) do
+      @original_invoker_config = Invoker.config
+    end
+
+    def mock_invoker_tld_as(domain)
+      Invoker.config = mock
+      Invoker.config.stubs(:tld).returns(domain)
+    end
+
+    after(:all) do
+      Invoker.config = @original_invoker_config
+    end
+
+    it "should not return 400 when host is lowercase" do
+      headers = { 'host' => 'somehost.com' }
+      mock_invoker_tld_as('test')
+      @http_connection.expects(:send_data).with() { |value| value =~ /404 Not Found/i }
+      @http_connection.expects(:close_connection_after_writing)
+      @balancer.headers_received(headers)
+    end
+
+    it "should not return 400 when host is written as HoSt" do
+      headers = { 'HoSt' => 'somehost.com' }
+      mock_invoker_tld_as('test')
+      @http_connection.expects(:send_data).with() { |value| value =~ /404 Not Found/i }
+      @http_connection.expects(:close_connection_after_writing)
+      @balancer.headers_received(headers)
+    end
+  end
+
   context "when Host field is missing in the request" do
     it "should return 400 as response when Host is missing" do
       headers = {}


### PR DESCRIPTION
Some http clients use to send the Host header in lowercase, like `host: mydomain.test`, and this breaks the invoker proxy.

It made me some troubles with both Cypress (who sends host header lower case), and BrowserSync proxy (same).

Since it looks like [lowercase headers are acceptable](https://stackoverflow.com/questions/5258977/are-http-headers-case-sensitive/5259004#:~:text=HTTP%20header%20names%20are%20case%2Dinsensitive%2C%20according%20to%20RFC%202616%3A&text=4.2%3A-,Each%20header%20field%20consists%20of%20a%20name%20followed%20by%20a,Field%20names%20are%20case%2Dinsensitive.), I've made a small change to make it work.

I've also added a couple of specs.
