### PR TITLE
Add support for EndeavourOS

### DIFF
--- a/lib/invoker/power/setup/distro/base.rb
+++ b/lib/invoker/power/setup/distro/base.rb
@@ -12,7 +12,7 @@ module Invoker
         end
 
         def self.distro_installer(tld)
-          if distro.start_with? "Arch Linux", "Manjaro Linux"
+          if distro.start_with? "Arch Linux", "Manjaro Linux", "'EndeavourOS'"
             require "invoker/power/setup/distro/arch"
             Arch.new(tld)
           elsif distro.start_with? "Debian"


### PR DESCRIPTION
EndeavourOS is a popular Arch-based distro. I've tested this on my local machine and it worked as expected.

The only caveat is that distro argument `'EndeavourOS'` is wrapped in single quotes, but that should be fine.